### PR TITLE
Don't installe poll when tests are imported.

### DIFF
--- a/vulcan/test/__init__.py
+++ b/vulcan/test/__init__.py
@@ -1,7 +1,6 @@
 from os import path
 
 from mock import patch, Mock, call
-from twisted.internet import epollreactor
 import yaml
 import twisted
 
@@ -9,7 +8,6 @@ import vulcan
 
 
 # twisted.internet.base.DelayedCall.debug = True
-epollreactor.install()
 
 from telephus.pool import CassandraClusterPool
 


### PR DESCRIPTION
This prevents tests from being runnable on non-Linux systems unecessarily.
