### PR TITLE
Use JSON for all error bodies, not just some

### DIFF
--- a/error.go
+++ b/error.go
@@ -18,10 +18,19 @@ func (r *HttpError) Error() string {
 }
 
 func NewHttpError(statusCode int) *HttpError {
+
+	encodedError, err := json.Marshal(map[string]interface{}{
+		"error": http.StatusText(statusCode),
+	})
+
+	if err != nil {
+		panic(err)
+	}
+
 	return &HttpError{
 		StatusCode: statusCode,
 		Status:     http.StatusText(statusCode),
-		Body:       []byte(http.StatusText(statusCode))}
+		Body:       encodedError}
 }
 
 func TooManyRequestsError(retrySeconds int) *HttpError {

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -121,7 +121,7 @@ func (s *ProxySuite) TestProxyAuthRequired(c *C) {
 
 	response, bodyBytes := s.Get(c, proxy.URL, http.Header{}, "")
 	c.Assert(response.StatusCode, Equals, http.StatusProxyAuthRequired)
-	c.Assert(string(bodyBytes), Equals, http.StatusText(http.StatusProxyAuthRequired))
+	c.Assert(string(bodyBytes), Equals, fmt.Sprintf(`{"error":"%s"}`, http.StatusText(http.StatusProxyAuthRequired)))
 }
 
 // Proxy denies request


### PR DESCRIPTION
- We always sent content-type application/json for error responses, but we weren't always sending back application/json.
