### PR TITLE
Add Metrics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,7 @@ go:
 
 install:
  - export PATH=$HOME/gopath/bin:$PATH
- - go get -v github.com/golang/glog
- - go get -v launchpad.net/gocheck
- - go get -v github.com/mailgun/gocql
- - go get -v github.com/mailgun/glogutils
- - go get -v -u github.com/robertkrimen/otto
- - go get -v -u github.com/coreos/go-etcd/etcd
- - go get -v -u github.com/mailgun/minheap
+ - make deps
 
 script:
  - go test -v ./...

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ deps:
 	go get -v -u github.com/robertkrimen/otto
 	go get -v -u github.com/coreos/go-etcd/etcd
 	go get -v -u github.com/mailgun/minheap
+	go get -v -u github.com/rcrowley/go-metrics
 clean:
 	find . -name flymake_* -delete
 

--- a/command/forward_test.go
+++ b/command/forward_test.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"encoding/json"
+	"github.com/mailgun/vulcan/metrics"
 	. "launchpad.net/gocheck"
 	"net/http"
 	"time"
@@ -21,16 +22,18 @@ func (s *ForwardSuite) TestForwardSuccess(c *C) {
 			Expected: &Forward{
 				Upstreams: []*Upstream{
 					&Upstream{
-						Id:     "http://localhost:5000",
-						Scheme: "http",
-						Port:   5000,
-						Host:   "localhost",
+						Id:      "http://localhost:5000",
+						Scheme:  "http",
+						Port:    5000,
+						Host:    "localhost",
+						Metrics: metrics.GetUpstreamMetrics("http_localhost_5000"),
 					},
 					&Upstream{
-						Id:     "http://localhost:5001",
-						Scheme: "http",
-						Port:   5001,
-						Host:   "localhost",
+						Id:      "http://localhost:5001",
+						Scheme:  "http",
+						Port:    5001,
+						Host:    "localhost",
+						Metrics: metrics.GetUpstreamMetrics("http_localhost_5001"),
 					},
 				},
 			},
@@ -43,16 +46,18 @@ func (s *ForwardSuite) TestForwardSuccess(c *C) {
 				},
 				Upstreams: []*Upstream{
 					&Upstream{
-						Id:     "http://localhost:5000",
-						Scheme: "http",
-						Port:   5000,
-						Host:   "localhost",
+						Id:      "http://localhost:5000",
+						Scheme:  "http",
+						Port:    5000,
+						Host:    "localhost",
+						Metrics: metrics.GetUpstreamMetrics("http_localhost_5000"),
 					},
 					&Upstream{
-						Id:     "http://localhost:5001",
-						Scheme: "http",
-						Port:   5001,
-						Host:   "localhost",
+						Id:      "http://localhost:5001",
+						Scheme:  "http",
+						Port:    5001,
+						Host:    "localhost",
+						Metrics: metrics.GetUpstreamMetrics("http_localhost_5001"),
 					},
 				},
 			},
@@ -90,16 +95,18 @@ func (s *ForwardSuite) TestForwardSuccess(c *C) {
 				RewritePath:   "/new/path",
 				Upstreams: []*Upstream{
 					&Upstream{
-						Id:     "http://localhost:5000",
-						Scheme: "http",
-						Port:   5000,
-						Host:   "localhost",
+						Id:      "http://localhost:5000",
+						Scheme:  "http",
+						Port:    5000,
+						Host:    "localhost",
+						Metrics: metrics.GetUpstreamMetrics("http_localhost_5000"),
 					},
 					&Upstream{
-						Id:     "http://localhost:5001",
-						Scheme: "http",
-						Port:   5001,
-						Host:   "localhost",
+						Id:      "http://localhost:5001",
+						Scheme:  "http",
+						Port:    5001,
+						Host:    "localhost",
+						Metrics: metrics.GetUpstreamMetrics("http_localhost_5001"),
 					},
 				},
 			},

--- a/command/upstream.go
+++ b/command/upstream.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"github.com/mailgun/vulcan/metrics"
 	"github.com/mailgun/vulcan/netutils"
 	"net/url"
 	"strconv"
@@ -11,10 +12,11 @@ import (
 // Upstream is HTTP server that will actually serve
 // the request that would be proxied
 type Upstream struct {
-	Scheme string
-	Host   string
-	Port   int
-	Id     string
+	Scheme  string
+	Host    string
+	Port    int
+	Id      string
+	Metrics *metrics.UpstreamMetrics
 }
 
 func NewUpstream(scheme string, host string, port int) (*Upstream, error) {
@@ -27,11 +29,17 @@ func NewUpstream(scheme string, host string, port int) (*Upstream, error) {
 		return nil, fmt.Errorf("Unsupported scheme: %s", scheme)
 	}
 
+	id := fmt.Sprintf("%s://%s:%d", scheme, host, port)
+	metricsId := fmt.Sprintf("%s_%s_%d", scheme, host, port)
+	metricsId = strings.Replace(metricsId, ".", "_", -1)
+	um := metrics.GetUpstreamMetrics(metricsId)
+
 	return &Upstream{
-		Id:     fmt.Sprintf("%s://%s:%d", scheme, host, port),
-		Scheme: scheme,
-		Host:   host,
-		Port:   port,
+		Id:      id,
+		Scheme:  scheme,
+		Host:    host,
+		Port:    port,
+		Metrics: um,
 	}, nil
 }
 

--- a/command/upstream_test.go
+++ b/command/upstream_test.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"encoding/json"
+	"github.com/mailgun/vulcan/metrics"
 	. "launchpad.net/gocheck"
 )
 
@@ -16,10 +17,11 @@ func (s *UpstreamSuite) TestNewUpstream(c *C) {
 		5000)
 	c.Assert(err, IsNil)
 	expected := Upstream{
-		Id:     "http://localhost:5000",
-		Scheme: "http",
-		Host:   "localhost",
-		Port:   5000,
+		Id:      "http://localhost:5000",
+		Scheme:  "http",
+		Host:    "localhost",
+		Port:    5000,
+		Metrics: metrics.GetUpstreamMetrics("http_localhost_5000"),
 	}
 	c.Assert(*u, DeepEquals, expected)
 }
@@ -28,10 +30,11 @@ func (s *UpstreamSuite) TestNewUpstreamNoPort(c *C) {
 	u, err := NewUpstreamFromString("http://localhost")
 	c.Assert(err, IsNil)
 	expected := Upstream{
-		Id:     "http://localhost:80",
-		Scheme: "http",
-		Host:   "localhost",
-		Port:   80,
+		Id:      "http://localhost:80",
+		Scheme:  "http",
+		Host:    "localhost",
+		Port:    80,
+		Metrics: metrics.GetUpstreamMetrics("http_localhost_80"),
 	}
 	c.Assert(*u, DeepEquals, expected)
 }
@@ -44,37 +47,41 @@ func (s *UpstreamSuite) TestUpstreamFromObj(c *C) {
 		{
 			Parse: `"http://google.com:5000"`,
 			Expected: Upstream{
-				Id:     "http://google.com:5000",
-				Scheme: "http",
-				Host:   "google.com",
-				Port:   5000,
+				Id:      "http://google.com:5000",
+				Scheme:  "http",
+				Host:    "google.com",
+				Port:    5000,
+				Metrics: metrics.GetUpstreamMetrics("http_google_com_5000"),
 			},
 		},
 		{
 			Parse: `"http://google.com:5000/"`,
 			Expected: Upstream{
-				Id:     "http://google.com:5000",
-				Scheme: "http",
-				Host:   "google.com",
-				Port:   5000,
+				Id:      "http://google.com:5000",
+				Scheme:  "http",
+				Host:    "google.com",
+				Port:    5000,
+				Metrics: metrics.GetUpstreamMetrics("http_google_com_5000"),
 			},
 		},
 		{
 			Parse: `{"scheme": "http", "host": "localhost", "port": 3000}`,
 			Expected: Upstream{
-				Id:     "http://localhost:3000",
-				Scheme: "http",
-				Host:   "localhost",
-				Port:   3000,
+				Id:      "http://localhost:3000",
+				Scheme:  "http",
+				Host:    "localhost",
+				Port:    3000,
+				Metrics: metrics.GetUpstreamMetrics("http_localhost_3000"),
 			},
 		},
 		{
 			Parse: `{"scheme": "https", "host": "localhost", "port": 4000}`,
 			Expected: Upstream{
-				Id:     "https://localhost:4000",
-				Scheme: "https",
-				Host:   "localhost",
-				Port:   4000,
+				Id:      "https://localhost:4000",
+				Scheme:  "https",
+				Host:    "localhost",
+				Port:    4000,
+				Metrics: metrics.GetUpstreamMetrics("https_localhost_4000"),
 			},
 		},
 	}

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,148 @@
+package metrics
+
+import (
+	"fmt"
+	gmetrics "github.com/rcrowley/go-metrics"
+	"net"
+	"sync"
+)
+
+type HttpMetrics struct {
+	prefix         string
+	rcmutex        sync.Mutex
+	ResponseCodes  map[int]gmetrics.Meter
+	ResponseRanges map[string]gmetrics.Meter
+}
+
+type ProxyMetrics struct {
+	Requests        gmetrics.Meter
+	CmdReply        gmetrics.Meter
+	CmdForward      gmetrics.Meter
+	RequestBodySize gmetrics.Histogram
+}
+
+type UpstreamMetrics struct {
+	Requests  gmetrics.Meter
+	Failovers gmetrics.Meter
+	Latency   gmetrics.Timer
+	Http      *HttpMetrics
+}
+
+func NewHttpMetrics(prefix string) HttpMetrics {
+	hm := HttpMetrics{prefix: prefix,
+		ResponseRanges: map[string]gmetrics.Meter{
+			"1XX": gmetrics.NewMeter(),
+			"2XX": gmetrics.NewMeter(),
+			"3XX": gmetrics.NewMeter(),
+			"4XX": gmetrics.NewMeter(),
+			"5XX": gmetrics.NewMeter(),
+			"UNK": gmetrics.NewMeter(),
+		},
+		ResponseCodes: make(map[int]gmetrics.Meter),
+	}
+
+	for k, v := range hm.ResponseRanges {
+		gmetrics.Register(fmt.Sprintf("%s.http.%s", prefix, k), v)
+	}
+
+	return hm
+}
+
+func NewProxyMetrics() ProxyMetrics {
+	pm := ProxyMetrics{
+		Requests:        gmetrics.NewMeter(),
+		CmdReply:        gmetrics.NewMeter(),
+		CmdForward:      gmetrics.NewMeter(),
+		RequestBodySize: gmetrics.NewHistogram(gmetrics.NewExpDecaySample(1028, 0.015)),
+	}
+
+	gmetrics.Register("vulcan.proxy.requests", pm.Requests)
+	gmetrics.Register("vulcan.proxy.cmd_reply", pm.CmdReply)
+	gmetrics.Register("vulcan.proxy.cmd_forward", pm.CmdForward)
+	gmetrics.Register("vulcan.proxy.request_body_size", pm.RequestBodySize)
+
+	return pm
+}
+
+var upstreamsLock sync.Mutex
+var upstreams map[string]*UpstreamMetrics
+
+func init() {
+	upstreams = make(map[string]*UpstreamMetrics)
+}
+
+func GetUpstreamMetrics(upstreamId string) *UpstreamMetrics {
+	upstreamsLock.Lock()
+	defer upstreamsLock.Unlock()
+
+	if um, ok := upstreams[upstreamId]; ok {
+		return um
+	}
+
+	um := NewUpstreamMetrics(upstreamId)
+	upstreams[upstreamId] = &um
+	return &um
+}
+
+func NewUpstreamMetrics(upstreamId string) UpstreamMetrics {
+	hm := NewHttpMetrics(fmt.Sprintf("vulcan.upstream.%s", upstreamId))
+	um := UpstreamMetrics{
+		Requests:  gmetrics.NewMeter(),
+		Failovers: gmetrics.NewMeter(),
+		Latency:   gmetrics.NewTimer(),
+		Http:      &hm,
+	}
+
+	gmetrics.Register(fmt.Sprintf("vulcan.upstream.%s.requests", upstreamId), um.Requests)
+	gmetrics.Register(fmt.Sprintf("vulcan.upstream.%s.latency", upstreamId), um.Failovers)
+	gmetrics.Register(fmt.Sprintf("vulcan.upstream.%s.failovers", upstreamId), um.Failovers)
+
+	return um
+}
+
+func AddOutput(outputType string) {
+	switch outputType {
+	// TODO(pquerna): Add graphite/statsd support
+	case "graphite":
+		addr, _ := net.ResolveTCPAddr("tcp", "127.0.0.1:2003")
+		go gmetrics.Graphite(gmetrics.DefaultRegistry, 10e9, "metrics", addr)
+	case "console":
+		ConsoleOutput()
+	default:
+		panic("unrecognized output type")
+	}
+}
+
+func (hm *HttpMetrics) markSingleCode(statusCode int) {
+	// TOOD(pquerna): profile to see if this is horrible
+	hm.rcmutex.Lock()
+	defer hm.rcmutex.Unlock()
+	var meter gmetrics.Meter
+
+	meter, ok := hm.ResponseCodes[statusCode]
+
+	if !ok {
+		hm.ResponseCodes[statusCode] = gmetrics.NewMeter()
+		meter = hm.ResponseCodes[statusCode]
+		gmetrics.Register(fmt.Sprintf("%s.http.status.%d", hm.prefix, statusCode), meter)
+	}
+
+	meter.Mark(1)
+}
+
+func (hm *HttpMetrics) MarkResponseCode(statusCode int) {
+	hm.markSingleCode(statusCode)
+	if statusCode >= 500 {
+		hm.ResponseRanges["5XX"].Mark(1)
+	} else if statusCode >= 200 && statusCode <= 299 {
+		hm.ResponseRanges["2XX"].Mark(1)
+	} else if statusCode >= 400 && statusCode <= 499 {
+		hm.ResponseRanges["2XX"].Mark(1)
+	} else if statusCode >= 300 && statusCode <= 399 {
+		hm.ResponseRanges["3XX"].Mark(1)
+	} else if statusCode >= 100 && statusCode <= 199 {
+		hm.ResponseRanges["1XX"].Mark(1)
+	} else {
+		hm.ResponseRanges["UNK"].Mark(1)
+	}
+}

--- a/metrics/output_console.go
+++ b/metrics/output_console.go
@@ -1,0 +1,68 @@
+package metrics
+
+import (
+	"github.com/golang/glog"
+	gmetrics "github.com/rcrowley/go-metrics"
+	"time"
+)
+
+func logForever(r gmetrics.Registry, d time.Duration) {
+	for {
+		r.Each(func(name string, i interface{}) {
+			switch m := i.(type) {
+			case gmetrics.Counter:
+				glog.Infof("counter %s\n", name)
+				glog.Infof("  count:       %9d\n", m.Count())
+			case gmetrics.Gauge:
+				glog.Infof("gauge %s\n", name)
+				glog.Infof("  value:       %9d\n", m.Value())
+			case gmetrics.Healthcheck:
+				m.Check()
+				glog.Infof("healthcheck %s\n", name)
+				glog.Infof("  error:       %v\n", m.Error())
+			case gmetrics.Histogram:
+				ps := m.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
+				glog.Infof("histogram %s\n", name)
+				glog.Infof("  count:       %9d\n", m.Count())
+				glog.Infof("  min:         %9d\n", m.Min())
+				glog.Infof("  max:         %9d\n", m.Max())
+				glog.Infof("  mean:        %12.2f\n", m.Mean())
+				glog.Infof("  stddev:      %12.2f\n", m.StdDev())
+				glog.Infof("  median:      %12.2f\n", ps[0])
+				glog.Infof("  75%%:         %12.2f\n", ps[1])
+				glog.Infof("  95%%:         %12.2f\n", ps[2])
+				glog.Infof("  99%%:         %12.2f\n", ps[3])
+				glog.Infof("  99.9%%:       %12.2f\n", ps[4])
+			case gmetrics.Meter:
+				glog.Infof("meter %s\n", name)
+				glog.Infof("  count:       %9d\n", m.Count())
+				glog.Infof("  1-min rate:  %12.2f\n", m.Rate1())
+				glog.Infof("  5-min rate:  %12.2f\n", m.Rate5())
+				glog.Infof("  15-min rate: %12.2f\n", m.Rate15())
+				glog.Infof("  mean rate:   %12.2f\n", m.RateMean())
+			case gmetrics.Timer:
+				ps := m.Percentiles([]float64{0.5, 0.75, 0.95, 0.99, 0.999})
+				glog.Infof("timer %s\n", name)
+				glog.Infof("  count:       %9d\n", m.Count())
+				glog.Infof("  min:         %9d\n", m.Min())
+				glog.Infof("  max:         %9d\n", m.Max())
+				glog.Infof("  mean:        %12.2f\n", m.Mean())
+				glog.Infof("  stddev:      %12.2f\n", m.StdDev())
+				glog.Infof("  median:      %12.2f\n", ps[0])
+				glog.Infof("  75%%:         %12.2f\n", ps[1])
+				glog.Infof("  95%%:         %12.2f\n", ps[2])
+				glog.Infof("  99%%:         %12.2f\n", ps[3])
+				glog.Infof("  99.9%%:       %12.2f\n", ps[4])
+				glog.Infof("  1-min rate:  %12.2f\n", m.Rate1())
+				glog.Infof("  5-min rate:  %12.2f\n", m.Rate5())
+				glog.Infof("  15-min rate: %12.2f\n", m.Rate15())
+				glog.Infof("  mean rate:   %12.2f\n", m.RateMean())
+			}
+		})
+		time.Sleep(d)
+	}
+}
+
+func ConsoleOutput() {
+	go logForever(gmetrics.DefaultRegistry, 10e9)
+}

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/mailgun/vulcan/control/js"
 	"github.com/mailgun/vulcan/loadbalance"
 	"github.com/mailgun/vulcan/loadbalance/roundrobin"
+	"github.com/mailgun/vulcan/metrics"
 	"github.com/mailgun/vulcan/netutils"
 	"github.com/mailgun/vulcan/ratelimit"
 	"github.com/mailgun/vulcan/timeutils"
@@ -24,6 +25,7 @@ type ProxySuite struct {
 	backend      *backend.MemoryBackend
 	limiter      ratelimit.RateLimiter
 	authHeaders  http.Header
+	metrics      metrics.ProxyMetrics
 }
 
 var _ = Suite(&ProxySuite{})
@@ -109,7 +111,9 @@ func (s *ProxySuite) newProxyWithTimeouts(
 		HttpDialTimeout:  dialTimeout,
 	}
 
-	proxy, err := NewReverseProxy(proxySettings)
+	s.metrics = metrics.NewProxyMetrics()
+
+	proxy, err := NewReverseProxy(&s.metrics, proxySettings)
 	if err != nil {
 		panic(err)
 	}

--- a/service/options.go
+++ b/service/options.go
@@ -35,6 +35,8 @@ func parseOptions() (*serviceOptions, error) {
 	flag.StringVar(&options.sslCertFile, "sslcert", "", "File containing SSL Certificates")
 	flag.StringVar(&options.sslKeyFile, "sslkey", "", "File containing SSL Private Key")
 
+	flag.StringVar(&options.metricsOutput, "metrics", "console", "Comma seperated list of where to send metrics.")
+
 	flag.Parse()
 
 	return options, nil
@@ -42,7 +44,8 @@ func parseOptions() (*serviceOptions, error) {
 
 type serviceOptions struct {
 	// Pid path
-	pidPath string
+	pidPath       string
+	metricsOutput string
 
 	codePath     string
 	backend      string


### PR DESCRIPTION
- Adds `-metrics` command line.  This can take a comma separated list of metrics outputs. Currently supports `console` and `graphite`.  Over time I think these should be more URL like, so you can have remote IPs/ports, but I think in general we need a more in depth configuration strategy.
- Adds dependency on https://github.com/rcrowley/go-metrics
- Downsides: Uses locks around:
  - Getting Upstream-specific metrics handlers
  - Getting all HTTP Response codes.
- I'm voting lets get it done, and then benchmark/profile separately rather than worry about it too much right now.
