### PR TITLE
(RFR) Profiling Improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,13 +44,13 @@ clean:
 	find . -name flymake_* -delete
 
 run: all
-	GOMAXPROCS=32 vulcan -cpuprofile vulcan.pprof -stderrthreshold=INFO -logtostderr=true -js=./examples/hello.js -b=memory -lb=roundrobin -log_dir=/tmp -logcleanup=24h
+	vulcan -stderrthreshold=INFO -logtostderr=true -js=./examples/hello.js -b=memory -lb=roundrobin -log_dir=/tmp -logcleanup=24h
 
 csrun: all
-	GOMAXPROCS=4 vulcan -stderrthreshold=INFO -logtostderr=true -b=cassandra -lb=roundrobin -csnode=localhost -cskeyspace=vulcan_dev -cscleanup=true -cscleanuptime=19:05 -log_dir=/tmp
+	vulcan -stderrthreshold=INFO -logtostderr=true -b=cassandra -lb=roundrobin -csnode=localhost -cskeyspace=vulcan_dev -cscleanup=true -cscleanuptime=19:05 -log_dir=/tmp
 
 run-discover: all
-	GOMAXPROCS=4 vulcan -stderrthreshold=INFO -logtostderr=true -js=./examples/discover.js -b=memory -lb=roundrobin -log_dir=/tmp -logcleanup=24h -etcd=http://127.0.0.1:4001
+	vulcan -stderrthreshold=INFO -logtostderr=true -js=./examples/discover.js -b=memory -lb=roundrobin -log_dir=/tmp -logcleanup=24h -etcd=http://127.0.0.1:4001
 
 sloccount:
 	 find . -name "*.go" -print0 | xargs -0 wc -l

--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,12 @@ deps:
 	go get -v -u github.com/coreos/go-etcd/etcd
 	go get -v -u github.com/mailgun/minheap
 	go get -v -u github.com/rcrowley/go-metrics
+
 clean:
 	find . -name flymake_* -delete
 
 run: all
-	GOMAXPROCS=4 vulcan -stderrthreshold=INFO -logtostderr=true -js=./examples/hello.js -b=memory -lb=roundrobin -log_dir=/tmp -logcleanup=24h
+	GOMAXPROCS=32 vulcan -cpuprofile vulcan.pprof -stderrthreshold=INFO -logtostderr=true -js=./examples/hello.js -b=memory -lb=roundrobin -log_dir=/tmp -logcleanup=24h
 
 csrun: all
 	GOMAXPROCS=4 vulcan -stderrthreshold=INFO -logtostderr=true -b=cassandra -lb=roundrobin -csnode=localhost -cskeyspace=vulcan_dev -cscleanup=true -cscleanuptime=19:05 -log_dir=/tmp

--- a/control/js/code.go
+++ b/control/js/code.go
@@ -1,30 +1,82 @@
 package js
 
 import (
+	"crypto/md5"
+	"encoding/hex"
 	"io/ioutil"
+	"os"
 )
 
 type CodeGetter interface {
 	GetCode() (string, error)
+	GetHash() (string, error)
 }
 
 type StringGetter struct {
-	Code string
+	code string
+	hash string
+}
+
+func NewStringGetter(code string) *StringGetter {
+	h := md5.New()
+	h.Write([]byte(code))
+	return &StringGetter{
+		code: code,
+		hash: hex.EncodeToString(h.Sum(nil)),
+	}
 }
 
 func (sg *StringGetter) GetCode() (string, error) {
-	return sg.Code, nil
+	return sg.code, nil
+}
+
+func (sg *StringGetter) GetHash() (string, error) {
+	return sg.hash, nil
 }
 
 type FileGetter struct {
-	Path string
+	path     string
+	hash     string
+	contents string
+	laststat os.FileInfo
+}
+
+func NewFileGetter(path string) *FileGetter {
+	return &FileGetter{
+		path: path,
+	}
 }
 
 func (fg *FileGetter) GetCode() (string, error) {
-	code, err := ioutil.ReadFile(fg.Path)
+	_, err := fg.GetHash()
+
 	if err != nil {
 		return "", err
-	} else {
-		return string(code), err
 	}
+
+	return fg.contents, nil
+}
+
+const SKIP_FILE_CACHE = false
+
+func (fg *FileGetter) GetHash() (string, error) {
+	st, err := os.Stat(fg.path)
+	if err != nil {
+		return "", err
+	}
+
+	if SKIP_FILE_CACHE || fg.laststat == nil || st.Size() != fg.laststat.Size() || st.ModTime() != fg.laststat.ModTime() {
+		fg.laststat = st
+
+		code, err := ioutil.ReadFile(fg.path)
+		if err != nil {
+			return "", err
+		}
+		fg.contents = string(code)
+		h := md5.New()
+		h.Write([]byte(code))
+		fg.hash = hex.EncodeToString(h.Sum(nil))
+	}
+
+	return fg.hash, nil
 }

--- a/control/js/code_test.go
+++ b/control/js/code_test.go
@@ -12,7 +12,7 @@ type CodeSuite struct{}
 var _ = Suite(&CodeSuite{})
 
 func (s *CodeSuite) TestStringGetter(c *C) {
-	code := &StringGetter{Code: "Hello"}
+	code := NewStringGetter("Hello")
 	out, err := code.GetCode()
 	c.Assert(err, Equals, nil)
 	c.Assert(out, Equals, "Hello")
@@ -22,7 +22,7 @@ func (s *CodeSuite) TestFileGetterSuccess(c *C) {
 	filePath := fmt.Sprintf("%s/_vulcan_test_js", os.TempDir())
 	err := ioutil.WriteFile(filePath, []byte("Hi"), 0666)
 	c.Assert(err, Equals, nil)
-	getter := &FileGetter{Path: filePath}
+	getter := NewFileGetter(filePath)
 	out, err := getter.GetCode()
 	c.Assert(err, Equals, nil)
 	c.Assert(out, Equals, "Hi")
@@ -30,7 +30,7 @@ func (s *CodeSuite) TestFileGetterSuccess(c *C) {
 
 func (s *CodeSuite) TestFileGetterFailure(c *C) {
 	filePath := fmt.Sprintf("%s/_vulcan_test_not_exists", os.TempDir())
-	getter := &FileGetter{Path: filePath}
+	getter := NewFileGetter(filePath)
 	_, err := getter.GetCode()
 	c.Assert(err, Not(Equals), nil)
 }

--- a/control/js/js_test.go
+++ b/control/js/js_test.go
@@ -20,10 +20,8 @@ var _ = Suite(&JsSuite{})
 func (s *JsSuite) executeCode(request *http.Request, code string) (interface{}, error) {
 	s.Client = &client.RecordingClient{}
 	controller := &JsController{
-		CodeGetter: &StringGetter{
-			Code: code,
-		},
-		Client: s.Client,
+		CodeGetter: NewStringGetter(code),
+		Client:     s.Client,
 	}
 	return controller.GetInstructions(request)
 }
@@ -31,10 +29,8 @@ func (s *JsSuite) executeCode(request *http.Request, code string) (interface{}, 
 func (s *JsSuite) convertError(request *http.Request, code string, err error) (*netutils.HttpError, error) {
 	s.Client = &client.RecordingClient{}
 	controller := &JsController{
-		CodeGetter: &StringGetter{
-			Code: code,
-		},
-		Client: s.Client,
+		CodeGetter: NewStringGetter(code),
+		Client:     s.Client,
 	}
 	return controller.ConvertError(request, err)
 }

--- a/proxy_test.go
+++ b/proxy_test.go
@@ -90,7 +90,7 @@ func (s *ProxySuite) loadJson(bytes []byte) map[string]interface{} {
 
 func (s *ProxySuite) newController(code string) *js.JsController {
 	return &js.JsController{
-		CodeGetter: &js.StringGetter{Code: code},
+		CodeGetter: js.NewStringGetter(code),
 	}
 }
 

--- a/service/options.go
+++ b/service/options.go
@@ -36,6 +36,7 @@ func parseOptions() (*serviceOptions, error) {
 	flag.StringVar(&options.sslKeyFile, "sslkey", "", "File containing SSL Private Key")
 
 	flag.StringVar(&options.metricsOutput, "metrics", "console", "Comma seperated list of where to send metrics.")
+	flag.StringVar(&options.cpuProfile, "cpuprofile", "", "Run with CPU Profiling enabled.")
 
 	flag.Parse()
 
@@ -53,6 +54,8 @@ type serviceOptions struct {
 
 	sslCertFile string
 	sslKeyFile  string
+
+	cpuProfile string
 
 	// Host and port to bind to
 	host     string

--- a/service/service.go
+++ b/service/service.go
@@ -162,7 +162,7 @@ func (s *Service) initProxy() (*vulcan.ReverseProxy, error) {
 	}
 
 	controller := &js.JsController{
-		CodeGetter:       &js.FileGetter{Path: s.options.codePath},
+		CodeGetter:       js.NewFileGetter(s.options.codePath),
 		DiscoveryService: discoveryService,
 	}
 

--- a/service/service.go
+++ b/service/service.go
@@ -23,6 +23,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"os"
+	"os/signal"
+	"runtime/pprof"
 	"strings"
 	"time"
 )
@@ -44,6 +46,25 @@ func NewService() (*Service, error) {
 
 // This is a blocking call, starts reverse proxy, connects to the backends, etc
 func (s *Service) Start() error {
+	if s.options.cpuProfile != "" {
+		f, err := os.Create(s.options.cpuProfile)
+		if err != nil {
+			return err
+		}
+		pprof.StartCPUProfile(f)
+		defer pprof.StopCPUProfile()
+
+		c := make(chan os.Signal, 1)
+		signal.Notify(c, os.Interrupt)
+		go func() {
+			for sig := range c {
+				glog.Errorf("captured %v, stopping profiler and exiting..", sig)
+				pprof.StopCPUProfile()
+				os.Exit(1)
+			}
+		}()
+	}
+
 	if err := s.writePid(); err != nil {
 		return err
 	}

--- a/vulcan/main.go
+++ b/vulcan/main.go
@@ -3,9 +3,14 @@ package main
 import (
 	"github.com/golang/glog"
 	"github.com/mailgun/vulcan/service"
+	"os"
+	"runtime"
 )
 
 func main() {
+	if os.Getenv("GOMAXPROCS") == "" {
+		runtime.GOMAXPROCS(runtime.NumCPU())
+	}
 	service, err := service.NewService()
 	if err != nil {
 		glog.Fatalf("Failed to init service, error:", err)


### PR DESCRIPTION
- Adds a `JsContext` which wraps Otto and the Handlers.
- Pool the `JsContext` so that they are re-used between requests.
- Add `-cpuprofile` option and catch `ctrl+c` to write it out to disk.
- Set `GOMAXPROCS` based on `runtime.NumCPU` if the environment variable was not set.

TODO:
- [ ] Benchmarks vs `master`
