### PR TITLE
(RFR) Pluggable Discovery backends

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ deps:
 	go get -v -u github.com/coreos/go-etcd/etcd
 	go get -v -u github.com/mailgun/minheap
 	go get -v -u github.com/rcrowley/go-metrics
+	go get -v -u github.com/rackspace/gophercloud/
 
 clean:
 	find . -name flymake_* -delete

--- a/discovery/discover.go
+++ b/discovery/discover.go
@@ -47,6 +47,4 @@ func New(discoveryUrl string) (Service, error) {
 		glog.Errorf("Bad URL for discovery: %s", discoveryUrl)
 		return nil, fmt.Errorf("invalid configuration: Unknown discovery scheme: %s", u.Scheme)
 	}
-
-	return nil, nil
 }

--- a/discovery/discover.go
+++ b/discovery/discover.go
@@ -11,13 +11,13 @@ type Service interface {
 	Get(key string) ([]string, error)
 }
 
-type DisabledDiscovery struct{}
+type NoopDiscovery struct{}
 
-func NewDisabledDiscovery() *DisabledDiscovery {
-	return &DisabledDiscovery{}
+func NewNoopDiscovery() *NoopDiscovery {
+	return &NoopDiscovery{}
 }
 
-func (d *DisabledDiscovery) Get(serviceName string) ([]string, error) {
+func (d *NoopDiscovery) Get(serviceName string) ([]string, error) {
 	return []string{}, nil
 }
 
@@ -34,8 +34,10 @@ func New(discoveryUrl string) (Service, error) {
 	}
 
 	switch u.Scheme {
+	case "noop":
+		return NewNoopDiscovery(), nil
 	case "disabled":
-		return NewDisabledDiscovery(), nil
+		return NewNoopDiscovery(), nil
 	case "rackspace":
 		return NewRackspaceFromUrl(u)
 	case "etcd":

--- a/discovery/etcd.go
+++ b/discovery/etcd.go
@@ -1,0 +1,71 @@
+package discovery
+
+import (
+	"github.com/coreos/go-etcd/etcd"
+	"github.com/golang/glog"
+)
+
+type Etcd struct {
+	client *etcd.Client
+	cache  map[string][]string
+}
+
+func NewEtcd(machines []string) *Etcd {
+	glog.Infof("Initialized etcd discovery service: %v", machines)
+
+	service := &Etcd{
+		client: etcd.NewClient(machines),
+		cache:  make(map[string][]string),
+	}
+
+	service.UpdateCache()
+
+	go service.Watch()
+
+	return service
+}
+
+func (e *Etcd) Watch() {
+	for {
+		_, err := e.client.Watch("/", 0, true, nil, nil)
+		if err != nil {
+			glog.Errorf("Error watching for a change: %v", err)
+			continue
+		}
+		glog.Infof("Etcd update detected")
+		e.UpdateCache()
+	}
+}
+
+func (e *Etcd) UpdateCache() {
+	glog.Infof("Updating the cache")
+
+	response, err := e.client.Get("/", false, true)
+
+	if err != nil {
+		glog.Errorf("Error updating cache: %v", err)
+	}
+
+	for _, node := range response.Node.Nodes {
+		serviceName := node.Key
+
+		upstreams := make([]string, len(node.Nodes))
+		for i, node := range node.Nodes {
+			upstreams[i] = node.Value
+		}
+
+		e.cache[serviceName] = upstreams
+	}
+
+	glog.Infof("Updated cache: %v", e.cache)
+}
+
+func (e *Etcd) Get(serviceName string) ([]string, error) {
+	if upstreams, ok := e.cache[serviceName]; ok {
+		glog.Infof("Found upstreams: %v %v", serviceName, upstreams)
+		return upstreams, nil
+	}
+
+	glog.Infof("Not found upstreams: %v", serviceName)
+	return []string{}, nil
+}

--- a/discovery/rackspace.go
+++ b/discovery/rackspace.go
@@ -1,0 +1,154 @@
+package discovery
+
+import (
+	"fmt"
+	"github.com/golang/glog"
+	"github.com/rackspace/gophercloud"
+	"net/url"
+	"sync"
+	"time"
+)
+
+type Rackspace struct {
+	accessProvider gophercloud.AccessProvider
+	mu             sync.RWMutex
+	servers        []gophercloud.Server
+	protocol       string
+	port           string
+	region         string
+}
+
+const DEFAULT_REGION = "dfw"
+const DEFAULT_PORT = ""
+const DEFAULT_PROTOCOL = "http"
+
+func NewRackspaceFromUrl(u *url.URL) (*Rackspace, error) {
+	var port = DEFAULT_PORT
+	var region = DEFAULT_REGION
+	var protocol = DEFAULT_PROTOCOL
+
+	qs := u.Query()
+
+	if qs.Get("port") != "" {
+		port = qs.Get("port")
+	}
+
+	if qs.Get("protocol") != "" {
+		protocol = qs.Get("protocol")
+	}
+
+	if qs.Get("region") != "" {
+		region = qs.Get("region")
+	}
+
+	if u.User == nil {
+		return nil, fmt.Errorf("Missing Username for Rackspace provider.")
+	}
+
+	apiKey, ok := u.User.Password()
+
+	if !ok {
+		return nil, fmt.Errorf("Missing API Key for Rackspace provider.")
+	}
+
+	auth := gophercloud.AuthOptions{
+		Username:    u.User.Username(),
+		ApiKey:      apiKey,
+		AllowReauth: true}
+
+	var identityRegion = "rackspace-us"
+
+	if region == "lon" {
+		identityRegion = "rackspace-uk"
+	}
+
+	ap, err := gophercloud.Authenticate(identityRegion, auth)
+
+	if err != nil {
+		return nil, err
+	}
+
+	r := &Rackspace{accessProvider: ap,
+		region:   region,
+		port:     port,
+		protocol: protocol,
+	}
+
+	err = r.UpdateCache()
+
+	if err != nil {
+		return nil, err
+	}
+
+	go r.Watch()
+
+	return r, nil
+}
+
+func (r *Rackspace) UpdateCache() error {
+	api, err := gophercloud.ServersApi(r.accessProvider,
+		gophercloud.ApiCriteria{
+			Name:      "cloudServersOpenStack",
+			VersionId: "2",
+			UrlChoice: gophercloud.PublicURL,
+			Region:    r.region,
+		})
+
+	if err != nil {
+		return err
+	}
+
+	servers, err := api.ListServers()
+
+	if err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.servers = servers
+
+	return nil
+}
+
+func (r *Rackspace) Watch() {
+	for {
+		// TOOD: expotential backoff on no changes?
+		time.Sleep(30000 * time.Millisecond)
+
+		err := r.UpdateCache()
+		if err != nil {
+			glog.Errorf("Error fetching servers from Rackspace: %v", err)
+		}
+	}
+}
+
+func (r *Rackspace) serverToUrl(s gophercloud.Server) string {
+	// TODO: support servicenet?
+	if r.port != "" {
+		return fmt.Sprintf("%s://%s:%s/", r.protocol, s.AccessIPv4, r.port)
+	}
+
+	return fmt.Sprintf("%s://%s/", r.protocol, s.AccessIPv4)
+}
+
+func (r *Rackspace) Get(serviceName string) ([]string, error) {
+	var out = []string{}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	for _, s := range r.servers {
+		if s.Status != "ACTIVE" {
+			continue
+		}
+		if val, ok := s.Metadata["rax:auto_scaling_group_id"]; ok {
+			if val == serviceName {
+				us := r.serverToUrl(s)
+				out = append(out, us)
+			}
+		}
+	}
+
+	return out, nil
+}

--- a/service/options.go
+++ b/service/options.go
@@ -30,6 +30,7 @@ func parseOptions() (*serviceOptions, error) {
 
 	flag.DurationVar(&options.cleanupPeriod, "logcleanup", time.Duration(24)*time.Hour, "How often should we remove unused golang logs (e.g. 24h, 1h, 7h)")
 
+	flag.StringVar(&options.discovery, "discovery", "disabled", "Discovery Backend e.g. 'disabled', 'rackspace://${USERNAME}:${API_KEY}', or 'etcd")
 	flag.Var(&options.etcdEndpoints, "etcd", "Etcd discovery service API endpoints")
 
 	flag.StringVar(&options.sslCertFile, "sslcert", "", "File containing SSL Certificates")
@@ -55,6 +56,7 @@ type serviceOptions struct {
 	sslCertFile string
 	sslKeyFile  string
 
+	discovery  string
 	cpuProfile string
 
 	// Host and port to bind to

--- a/service/service.go
+++ b/service/service.go
@@ -157,8 +157,19 @@ func (s *Service) initProxy() (*vulcan.ReverseProxy, error) {
 	}
 
 	var discoveryService discovery.Service
-	if len(s.options.etcdEndpoints) > 0 {
-		discoveryService = discovery.NewEtcd(s.options.etcdEndpoints)
+
+	if s.options.discovery != "" {
+		discoveryUrl := s.options.discovery
+		if s.options.discovery == "etcd" {
+			// TODO remove this compat hack?
+			discoveryUrl = "etcd://" + strings.Join(s.options.etcdEndpoints, ",")
+			discoveryService = discovery.NewEtcd(s.options.etcdEndpoints)
+		}
+
+		discoveryService, err = discovery.New(discoveryUrl)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	controller := &js.JsController{

--- a/timeutils/timeutils.go
+++ b/timeutils/timeutils.go
@@ -2,6 +2,8 @@ package timeutils
 
 import (
 	"fmt"
+	"math"
+	"math/rand"
 	"time"
 )
 
@@ -21,4 +23,33 @@ func RoundedBucket(t time.Time, p time.Duration) time.Time {
 func GetHit(now time.Time, key string, period time.Duration) string {
 	return fmt.Sprintf(
 		"%s_%s_%d", key, period.String(), RoundedBucket(now, period).Unix())
+}
+
+type BackoffTimer struct {
+	maxDelay float64
+	minDelay float64
+	Delay    float64
+	retries  int
+}
+
+const factor = 2.7182818284590451
+const jitter = 0.11962656472
+
+func NewBackoffTimer(min float64, max float64) *BackoffTimer {
+	bo := &BackoffTimer{minDelay: min, maxDelay: max, Delay: min}
+	bo.bump(min)
+	return bo
+}
+
+func (bo *BackoffTimer) bump(bound float64) {
+	proposed := math.Min(bo.Delay*factor, bound)
+	bo.Delay = rand.NormFloat64()*(proposed*jitter) + proposed
+}
+
+func (bo *BackoffTimer) Reset() {
+	bo.bump(bo.minDelay)
+}
+
+func (bo *BackoffTimer) Increase() {
+	bo.bump(bo.maxDelay)
 }

--- a/timeutils/timeutils_test.go
+++ b/timeutils/timeutils_test.go
@@ -88,3 +88,17 @@ func (s *TimeUtilsSuite) TestTimes(c *C) {
 	tm := &RealTime{}
 	c.Assert(tm.UtcNow(), NotNil)
 }
+
+func (s *TimeUtilsSuite) TestBackoffTimer(c *C) {
+	bo := NewBackoffTimer(1.0, 30.0)
+	val := bo.Delay
+	bo.Increase()
+	if val > bo.Delay {
+		c.Errorf("delay didn't increase? %f > %f", val, bo.Delay)
+	}
+	val = bo.Delay
+	bo.Reset()
+	if bo.Delay > val {
+		c.Errorf("delay didn't decrease? %f < %f", bo.Delay, val)
+	}
+}


### PR DESCRIPTION
Addresses #32 
- Makes the discovery subsystem more pluggable, adding `disabled`, `etcd` and `rackspace` backends.
- Rackspace backend searches for UUIDs of an Auto Scaling Group by default, but can look at other metadata on the Server instance.

Example Javascript using this: 

``` javascript

function handle(request) {
    return {upstreams: discover('489c20b5-4df2-41fa-ab7e-abd9375e82a5')}
}

```

With the following Command line args: `OS_USERNAME=your_username OS_PASSWORD=you_apikey vulcan -discovery "rackspace:///?region=ord&protocol=http"`
