### PR TITLE
Buffer large requests to disk

### DIFF
--- a/netutils/buffer.go
+++ b/netutils/buffer.go
@@ -1,0 +1,138 @@
+package netutils
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+)
+
+// TODO: make configurable
+const MEMORY_BUFFER_LIMIT = 1024 * 1024 * 1024
+
+// Constraints:
+//  - Implements io.Reader
+//  - Implements Seek(0, 0)
+//	- Designed for Write once, Read many times.
+type multiReaderSeek struct {
+	length  int64
+	readers []io.ReadSeeker
+	mr      io.Reader
+	cleanup CleanupFunc
+}
+
+type CleanupFunc func() error
+
+func MultiReaderSeeker(cleanup CleanupFunc, readers ...io.ReadSeeker) *multiReaderSeek {
+	ior := make([]io.Reader, len(readers))
+	for i, arg := range readers {
+		ior[i] = arg.(io.Reader)
+	}
+
+	return &multiReaderSeek{length: -1,
+		readers: readers,
+		mr:      io.MultiReader(ior...),
+		cleanup: cleanup}
+}
+
+func (mr *multiReaderSeek) Close() (err error) {
+	if mr.cleanup != nil {
+		return mr.cleanup()
+	}
+	return nil
+}
+
+func (mr *multiReaderSeek) Read(p []byte) (n int, err error) {
+	return mr.mr.Read(p)
+}
+
+func (mr *multiReaderSeek) Len() (int64, error) {
+	if mr.length >= 0 {
+		return mr.length, nil
+	}
+
+	var totalLen int64
+	for _, reader := range mr.readers {
+		switch reader.(type) {
+		case *bytes.Reader:
+			b := reader.(*bytes.Reader)
+			totalLen += int64(b.Len())
+		case *os.File:
+			// STAT
+			f := reader.(*os.File)
+			st, err := f.Stat()
+			if err != nil {
+				return 0, err
+			}
+			totalLen += st.Size()
+		default:
+			return 0, fmt.Errorf("multiReaderSeek: type for Len: %s", reader)
+		}
+	}
+
+	mr.length = totalLen
+
+	return mr.length, nil
+}
+
+func (mr *multiReaderSeek) Seek(offset int64, whence int) (int64, error) {
+	// TODO: implement other whence
+	// TODO: implement real offsets
+
+	if whence != 0 {
+		return 0, fmt.Errorf("multiReaderSeek: unsupported whence")
+	}
+
+	if offset != 0 {
+		return 0, fmt.Errorf("multiReaderSeek: unsupported offset")
+	}
+
+	for _, seeker := range mr.readers {
+		seeker.Seek(0, 0)
+	}
+
+	ior := make([]io.Reader, len(mr.readers))
+	for i, arg := range mr.readers {
+		ior[i] = arg.(io.Reader)
+	}
+	mr.mr = io.MultiReader(ior...)
+
+	return 0, nil
+}
+
+func NewBodyBuffer(input io.Reader) (*multiReaderSeek, error) {
+	var f *os.File
+	ior := make([]io.ReadSeeker, 0, 2)
+	lr := &io.LimitedReader{input, MEMORY_BUFFER_LIMIT}
+	buffer, err := ioutil.ReadAll(lr)
+
+	if err != nil {
+		return nil, err
+	}
+
+	ior = append(ior, bytes.NewReader(buffer))
+	if lr.N <= 0 {
+		f, err := ioutil.TempFile("", "vulcan-bodies-")
+		if err != nil {
+			return nil, err
+		}
+
+		_, err = io.Copy(f, input)
+		if err != nil {
+			return nil, err
+		}
+		f.Seek(0, 0)
+		ior = append(ior, f)
+	}
+
+	mrs := MultiReaderSeeker(func() error {
+		if f != nil {
+			os.Remove(f.Name())
+			f.Close()
+		}
+		return nil
+	}, ior...)
+
+	return mrs, nil
+}

--- a/netutils/buffer.go
+++ b/netutils/buffer.go
@@ -123,6 +123,8 @@ func NewBodyBuffer(input io.Reader) (*multiReaderSeek, error) {
 			return nil, err
 		}
 
+		os.Remove(f.Name())
+
 		_, err = io.Copy(f, input)
 		if err != nil {
 			return nil, err
@@ -133,7 +135,6 @@ func NewBodyBuffer(input io.Reader) (*multiReaderSeek, error) {
 
 	mrs := MultiReaderSeeker(func() error {
 		if f != nil {
-			os.Remove(f.Name())
 			f.Close()
 		}
 		return nil

--- a/netutils/buffer_test.go
+++ b/netutils/buffer_test.go
@@ -1,0 +1,93 @@
+package netutils
+
+import (
+	"bytes"
+	"crypto/md5"
+	"encoding/hex"
+	"io"
+	"io/ioutil"
+	. "launchpad.net/gocheck"
+	"os"
+)
+
+type BufferSuite struct{}
+
+var _ = Suite(&BufferSuite{})
+
+func createReaderOfSize(size int64) (reader io.Reader, hash string) {
+	f, err := os.Open("/dev/urandom")
+	if err != nil {
+		panic(err)
+	}
+
+	b := make([]byte, int(size))
+
+	_, err = io.ReadFull(f, b)
+
+	if err != nil {
+		panic(err)
+	}
+
+	h := md5.New()
+	h.Write(b)
+	return bytes.NewReader(b), hex.EncodeToString(h.Sum(nil))
+}
+
+func hashOfReader(r io.Reader) string {
+	h := md5.New()
+	tr := io.TeeReader(r, h)
+	_, _ = io.Copy(ioutil.Discard, tr)
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+func (s *BufferSuite) TestSmallBuffer(c *C) {
+	r, hash := createReaderOfSize(1)
+	bb, err := NewBodyBuffer(r)
+	c.Assert(err, IsNil)
+	c.Assert(hashOfReader(bb), Equals, hash)
+}
+
+func (s *BufferSuite) TestBigBuffer(c *C) {
+	r, hash := createReaderOfSize(13631488)
+	bb, err := NewBodyBuffer(r)
+	c.Assert(err, IsNil)
+	c.Assert(hashOfReader(bb), Equals, hash)
+}
+
+func (s *BufferSuite) TestSeek(c *C) {
+	tlen := int64(1057576)
+	r, hash := createReaderOfSize(tlen)
+	bb, err := NewBodyBuffer(r)
+
+	c.Assert(err, IsNil)
+	c.Assert(hashOfReader(bb), Equals, hash)
+	l, err := bb.TotalSize()
+	c.Assert(err, IsNil)
+	c.Assert(l, Equals, tlen)
+
+	bb.Seek(0, 0)
+	c.Assert(hashOfReader(bb), Equals, hash)
+	l, err = bb.TotalSize()
+	c.Assert(err, IsNil)
+	c.Assert(l, Equals, tlen)
+}
+
+func (s *BufferSuite) TestSeekFirst(c *C) {
+	tlen := int64(1057576)
+	r, hash := createReaderOfSize(tlen)
+	bb, err := NewBodyBuffer(r)
+
+	l, err := bb.TotalSize()
+	c.Assert(err, IsNil)
+	c.Assert(l, Equals, tlen)
+
+	c.Assert(err, IsNil)
+	c.Assert(hashOfReader(bb), Equals, hash)
+
+	bb.Seek(0, 0)
+
+	c.Assert(hashOfReader(bb), Equals, hash)
+	l, err = bb.TotalSize()
+	c.Assert(err, IsNil)
+	c.Assert(l, Equals, tlen)
+}

--- a/proxy.go
+++ b/proxy.go
@@ -265,6 +265,7 @@ func (p *ReverseProxy) proxyRequest(
 
 	p.metrics.RequestBodySize.Update(requestLength)
 	req.Body = body
+	defer body.Close()
 
 	for i := 0; i < len(endpoints); i++ {
 		_, err := body.Seek(0, 0)

--- a/proxy.go
+++ b/proxy.go
@@ -257,14 +257,13 @@ func (p *ReverseProxy) proxyRequest(
 		return 0, netutils.NewHttpError(http.StatusBadRequest)
 	}
 
-	l, err := body.Len()
+	requestLength, err := body.Len()
 	if err != nil {
 		glog.Errorf("Failed to read stored body length: %s", err)
 		return 0, netutils.NewHttpError(http.StatusInternalServerError)
 	}
 
-	p.metrics.RequestBodySize.Update(l)
-	requestLength := l
+	p.metrics.RequestBodySize.Update(requestLength)
 	req.Body = body
 
 	for i := 0; i < len(endpoints); i++ {

--- a/proxy.go
+++ b/proxy.go
@@ -257,7 +257,7 @@ func (p *ReverseProxy) proxyRequest(
 		return 0, netutils.NewHttpError(http.StatusBadRequest)
 	}
 
-	requestLength, err := body.Len()
+	requestLength, err := body.TotalSize()
 	if err != nil {
 		glog.Errorf("Failed to read stored body length: %s", err)
 		return 0, netutils.NewHttpError(http.StatusInternalServerError)


### PR DESCRIPTION
- Request bodies over 1mb will be buffered to a disk
- Hacked around with a `MultiReader` that supports a basic reset to seek back to zero.
