### PR TITLE
Allow middlewares to modify the request.

### DIFF
--- a/location/httploc/httploc.go
+++ b/location/httploc/httploc.go
@@ -7,7 +7,6 @@ import (
 	timetools "github.com/mailgun/gotools-time"
 	. "github.com/mailgun/vulcan/endpoint"
 	"github.com/mailgun/vulcan/failover"
-	"github.com/mailgun/vulcan/headers"
 	. "github.com/mailgun/vulcan/loadbalance"
 	. "github.com/mailgun/vulcan/middleware"
 	"github.com/mailgun/vulcan/netutils"
@@ -15,7 +14,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"strings"
 	"time"
 )
 
@@ -70,7 +68,8 @@ func NewLocationWithOptions(id string, loadBalancer LoadBalancer, o Options) (*H
 	observerChain.Add(BalancerId, loadBalancer)
 
 	middlewareChain := NewMiddlewareChain()
-	middlewareChain.Add(BalancerId, 0, loadBalancer)
+	middlewareChain.Add(RewriterId, -2, &Rewriter{TrustForwardHeader: o.TrustForwardHeader, Hostname: o.Hostname})
+	middlewareChain.Add(BalancerId, -1, loadBalancer)
 
 	return &HttpLocation{
 		id:           id,
@@ -97,6 +96,7 @@ func (l *HttpLocation) GetObserverChain() *ObserverChain {
 
 // Round trips the request to one of the endpoints and returns the response
 func (l *HttpLocation) RoundTrip(req Request) (*http.Response, error) {
+	originalRequest := req.GetHttpRequest()
 	for {
 		_, err := req.GetBody().Seek(0, 0)
 		if err != nil {
@@ -109,12 +109,13 @@ func (l *HttpLocation) RoundTrip(req Request) (*http.Response, error) {
 			return nil, err
 		}
 
-		// Adds headers, changes urls
-		newRequest := l.rewriteRequest(req.GetHttpRequest(), endpoint)
+		// Adds headers, changes urls. Note that we rewrite request each time we proxy it to the
+		// endpoint, so that each try get's a fresh start
+		req.SetHttpRequest(l.copyRequest(originalRequest, endpoint))
 
 		// In case if error is not nil, we allow load balancer to choose the next endpoint
 		// e.g. to do request failover. Nil error means that we got proxied the request successfully.
-		response, err := l.proxyToEndpoint(endpoint, req, newRequest)
+		response, err := l.proxyToEndpoint(endpoint, req)
 		if l.options.ShouldFailover(req) {
 			continue
 		} else {
@@ -141,7 +142,7 @@ func (l *HttpLocation) unwindIter(it *MiddlewareIter, req Request, a Attempt) {
 }
 
 // Proxy the request to the given endpoint, execute observers and middlewares chains
-func (l *HttpLocation) proxyToEndpoint(endpoint Endpoint, req Request, httpReq *http.Request) (*http.Response, error) {
+func (l *HttpLocation) proxyToEndpoint(endpoint Endpoint, req Request) (*http.Response, error) {
 
 	a := &BaseAttempt{Endpoint: endpoint}
 
@@ -164,13 +165,12 @@ func (l *HttpLocation) proxyToEndpoint(endpoint Endpoint, req Request, httpReq *
 
 	// Forward the request and mirror the response
 	start := l.options.TimeProvider.UtcNow()
-	a.Response, a.Error = l.transport.RoundTrip(httpReq)
+	a.Response, a.Error = l.transport.RoundTrip(req.GetHttpRequest())
 	a.Duration = l.options.TimeProvider.UtcNow().Sub(start)
 	return a.Response, a.Error
 }
 
-// This function alters the original request - adds/removes headers, removes hop headers, changes the request path.
-func (l *HttpLocation) rewriteRequest(req *http.Request, endpoint Endpoint) *http.Request {
+func (l *HttpLocation) copyRequest(req *http.Request, endpoint Endpoint) *http.Request {
 	outReq := new(http.Request)
 	*outReq = *req // includes shallow copies of maps, but we handle this below
 
@@ -181,36 +181,12 @@ func (l *HttpLocation) rewriteRequest(req *http.Request, endpoint Endpoint) *htt
 	outReq.Proto = "HTTP/1.1"
 	outReq.ProtoMajor = 1
 	outReq.ProtoMinor = 1
+
+	// Overwrite close flag so we can keep persistent connection for the backend servers
 	outReq.Close = false
 
 	outReq.Header = make(http.Header)
 	netutils.CopyHeaders(outReq.Header, req.Header)
-
-	if clientIP, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
-		if l.options.TrustForwardHeader {
-			if prior, ok := outReq.Header[headers.XForwardedFor]; ok {
-				clientIP = strings.Join(prior, ", ") + ", " + clientIP
-			}
-		}
-		outReq.Header.Set(headers.XForwardedFor, clientIP)
-	}
-
-	if xfp := req.Header.Get(headers.XForwardedProto); xfp != "" && l.options.TrustForwardHeader {
-		outReq.Header.Set(headers.XForwardedProto, xfp)
-	} else if req.TLS != nil {
-		outReq.Header.Set(headers.XForwardedProto, "https")
-	} else {
-		outReq.Header.Set(headers.XForwardedProto, "http")
-	}
-
-	if req.Host != "" {
-		outReq.Header.Set(headers.XForwardedHost, req.Host)
-	}
-	outReq.Header.Set(headers.XForwardedServer, l.options.Hostname)
-
-	// Remove hop-by-hop headers to the backend.  Especially important is "Connection" because we want a persistent
-	// connection, regardless of what the client sent to us.
-	netutils.RemoveHeaders(headers.HopHeaders, outReq.Header)
 	return outReq
 }
 
@@ -246,4 +222,5 @@ func parseOptions(o Options) (Options, error) {
 
 const (
 	BalancerId = "__loadBalancer"
+	RewriterId = "__rewriter"
 )

--- a/location/httploc/httploc_test.go
+++ b/location/httploc/httploc_test.go
@@ -1,6 +1,7 @@
 package httploc
 
 import (
+	"fmt"
 	timetools "github.com/mailgun/gotools-time"
 	"github.com/mailgun/vulcan"
 	. "github.com/mailgun/vulcan/endpoint"
@@ -235,4 +236,66 @@ func (s *LocSuite) TestForwardedHeaders(c *C) {
 	hdr.Set(headers.XForwardedFor, "192.168.1.1")
 
 	Get(c, proxy.URL, hdr, "hello!")
+}
+
+// Test scenario when middleware intercepts the request
+func (s *LocSuite) TestMiddlewareAddsHeader(c *C) {
+	var capturedHeader []string
+	server := NewTestServer(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeader = r.Header["X-Vulcan-Call"]
+		w.Write([]byte("Hi, I'm endpoint"))
+	})
+	defer server.Close()
+
+	location, proxy := s.newProxy(s.newRoundRobin(server.URL))
+	defer proxy.Close()
+
+	m := &MiddlewareWrapper{
+		OnRequest: func(r Request) (*http.Response, error) {
+			r.GetHttpRequest().Header["X-Vulcan-Call"] = []string{"hello"}
+			return nil, nil
+		},
+		OnResponse: func(r Request, a Attempt) {
+		},
+	}
+
+	location.GetMiddlewareChain().Add("m", 0, m)
+
+	response, bodyBytes := Get(c, proxy.URL, nil, "hello!")
+	c.Assert(response.StatusCode, Equals, http.StatusOK)
+	c.Assert(capturedHeader, DeepEquals, []string{"hello"})
+	c.Assert(string(bodyBytes), Equals, "Hi, I'm endpoint")
+}
+
+// Make sure that request gets cleaned up in case of the failover
+// and the changes made by middlewares are being erased
+func (s *LocSuite) TestMiddlewareAddsHeaderOnFailover(c *C) {
+
+	var capturedHeader []string
+	server := NewTestServer(func(w http.ResponseWriter, r *http.Request) {
+		capturedHeader = r.Header["X-Vulcan-Call"]
+		w.Write([]byte("Hi, I'm endpoint"))
+	})
+	defer server.Close()
+
+	location, proxy := s.newProxy(s.newRoundRobin("http://localhost:63999", server.URL))
+	defer proxy.Close()
+
+	counter := 0
+	m := &MiddlewareWrapper{
+		OnRequest: func(r Request) (*http.Response, error) {
+			r.GetHttpRequest().Header["X-Vulcan-Call"] = []string{fmt.Sprintf("hello %d", counter)}
+			counter += 1
+			return nil, nil
+		},
+		OnResponse: func(r Request, a Attempt) {
+		},
+	}
+
+	location.GetMiddlewareChain().Add("m", 0, m)
+
+	response, bodyBytes := Get(c, proxy.URL, nil, "hello!")
+	c.Assert(response.StatusCode, Equals, http.StatusOK)
+	c.Assert(capturedHeader, DeepEquals, []string{"hello 1"})
+	c.Assert(string(bodyBytes), Equals, "Hi, I'm endpoint")
 }

--- a/location/httploc/rewrite.go
+++ b/location/httploc/rewrite.go
@@ -1,0 +1,51 @@
+package httploc
+
+import (
+	"github.com/mailgun/vulcan/headers"
+	"github.com/mailgun/vulcan/netutils"
+	. "github.com/mailgun/vulcan/request"
+	"net"
+	"net/http"
+	"strings"
+)
+
+// Rewrites incom
+type Rewriter struct {
+	TrustForwardHeader bool
+	Hostname           string
+}
+
+func (rw *Rewriter) ProcessRequest(r Request) (*http.Response, error) {
+	req := r.GetHttpRequest()
+
+	if clientIP, _, err := net.SplitHostPort(req.RemoteAddr); err == nil {
+		if rw.TrustForwardHeader {
+			if prior, ok := req.Header[headers.XForwardedFor]; ok {
+				clientIP = strings.Join(prior, ", ") + ", " + clientIP
+			}
+		}
+		req.Header.Set(headers.XForwardedFor, clientIP)
+	}
+
+	if xfp := req.Header.Get(headers.XForwardedProto); xfp != "" && rw.TrustForwardHeader {
+		req.Header.Set(headers.XForwardedProto, xfp)
+	} else if req.TLS != nil {
+		req.Header.Set(headers.XForwardedProto, "https")
+	} else {
+		req.Header.Set(headers.XForwardedProto, "http")
+	}
+
+	if req.Host != "" {
+		req.Header.Set(headers.XForwardedHost, req.Host)
+	}
+	req.Header.Set(headers.XForwardedServer, rw.Hostname)
+
+	// Remove hop-by-hop headers to the backend.  Especially important is "Connection" because we want a persistent
+	// connection, regardless of what the client sent to us.
+	netutils.RemoveHeaders(headers.HopHeaders, req.Header)
+
+	return nil, nil
+}
+
+func (tl *Rewriter) ProcessResponse(r Request, a Attempt) {
+}

--- a/request/request.go
+++ b/request/request.go
@@ -12,6 +12,7 @@ import (
 // Wrapper around http request that provides more info about http.Request
 type Request interface {
 	GetHttpRequest() *http.Request // Original http request
+	SetHttpRequest(*http.Request)  // Can be used to set http request
 	GetId() int64                  // Request id that is unique to this running process
 	GetBody() netutils.MultiReader // Request body fully read and stored in effective manner (buffered to disk for large requests)
 	AddAttempt(Attempt)            // Add last proxy attempt to the request
@@ -63,6 +64,10 @@ func (br *BaseRequest) String() string {
 
 func (br *BaseRequest) GetHttpRequest() *http.Request {
 	return br.HttpRequest
+}
+
+func (br *BaseRequest) SetHttpRequest(r *http.Request) {
+	br.HttpRequest = r
 }
 
 func (br *BaseRequest) GetId() int64 {


### PR DESCRIPTION
There was a bug in the httploc implementation that passed in the different request to the endpoint and middlewares,
so all changes to middlewares were lost. Fixes #51
