### PR TITLE
Preserve encoded values in proxied URLs.

### DIFF
--- a/location/httploc/httploc.go
+++ b/location/httploc/httploc.go
@@ -271,8 +271,10 @@ func (l *HttpLocation) copyRequest(req *http.Request, body netutils.MultiReader,
 	// Set the body to the enhanced body that can be re-read multiple times and buffered to disk
 	outReq.Body = body
 
-	outReq.URL.Scheme = endpoint.GetUrl().Scheme
-	outReq.URL.Host = endpoint.GetUrl().Host
+	endpointURL := endpoint.GetUrl()
+	outReq.URL.Scheme = endpointURL.Scheme
+	outReq.URL.Host = endpointURL.Host
+	outReq.URL.Opaque = req.RequestURI
 	outReq.URL.RawQuery = req.URL.RawQuery
 
 	outReq.Proto = "HTTP/1.1"


### PR DESCRIPTION
When proxying requests to URLs that contain encoded URLs, the requests contained
URL is decoded because Go stores a URL's Path field in decoded form. As a result,
any encoded values in a URL are lost.

Fixes #65
