### PR TITLE
Sort routes before compile into matchers

### DIFF
--- a/route/exproute/exproute.go
+++ b/route/exproute/exproute.go
@@ -8,9 +8,11 @@ package exproute
 
 import (
 	"fmt"
+	"sort"
+	"sync"
+
 	"github.com/mailgun/vulcan/location"
 	"github.com/mailgun/vulcan/request"
-	"sync"
 )
 
 type ExpRouter struct {
@@ -52,9 +54,16 @@ func (e *ExpRouter) AddLocation(expr string, l location.Location) error {
 }
 
 func (e *ExpRouter) compile() error {
+	var exprs = []string{}
+	for expr, _ := range e.routes {
+		exprs = append(exprs, expr)
+	}
+	sort.Sort(sort.Reverse(sort.StringSlice(exprs)))
+
 	matchers := []matcher{}
 	i := 0
-	for expr, location := range e.routes {
+	for _, expr := range exprs {
+		location := e.routes[expr]
 		matcher, err := parseExpression(expr, location)
 		if err != nil {
 			return err

--- a/route/exproute/exproute_test.go
+++ b/route/exproute/exproute_test.go
@@ -160,7 +160,7 @@ func (s *RouteSuite) TestMatchByMethod(c *C) {
 	c.Assert(out, Equals, l2)
 }
 
-func (s *RouteSuite) TestMatchLongestPath(c *C) {
+func (s *RouteSuite) TestTrieMatchLongestPath(c *C) {
 	r := NewExpRouter()
 
 	l1 := makeLoc("loc1")
@@ -171,6 +171,22 @@ func (s *RouteSuite) TestMatchLongestPath(c *C) {
 
 	req := makeReq("http://google.com/r/hello")
 	req.GetHttpRequest().Method = "POST"
+
+	out, err := r.Route(req)
+	c.Assert(err, IsNil)
+	c.Assert(out, Equals, l2)
+}
+
+func (s *RouteSuite) TestRegexpMatchLongestPath(c *C) {
+	r := NewExpRouter()
+
+	l1 := makeLoc("loc1")
+	c.Assert(r.AddLocation(`RegexpRoute("/r")`, l1), IsNil)
+
+	l2 := makeLoc("loc2")
+	c.Assert(r.AddLocation(`RegexpRoute("/r/hello")`, l2), IsNil)
+
+	req := makeReq("http://google.com/r/hello")
 
 	out, err := r.Route(req)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Hi All,

I got an issue when using the ExpRouter, for example, I have defined two locations:

Location 1's router matcher is `RegexpRoute("/hello")`
Location 2's router matcher is `RegexpRoute("/")`

When ExpRouter compile those two locations into matchers, it haven't sort them, Location 2 may be compiled first, so it will match those `/hello/world` requests that should be matched by Location 1.

This pull request sorted locations by the router matcher's length before compile them into matchers, it should be able to fix above case.
