### PR TITLE
Profiling

### DIFF
--- a/netutils/buffer_test.go
+++ b/netutils/buffer_test.go
@@ -112,3 +112,29 @@ func (s *BufferSuite) TestLimitExceeds(c *C) {
 	c.Assert(err, FitsTypeOf, &MaxSizeReachedError{})
 	c.Assert(bb, IsNil)
 }
+
+func (s *BufferSuite) TestWriteToBigBuffer(c *C) {
+	l := int64(13631488)
+	r, hash := createReaderOfSize(l)
+	bb, err := NewBodyBuffer(r)
+	c.Assert(err, IsNil)
+
+	other := &bytes.Buffer{}
+	wrote, err := bb.WriteTo(other)
+	c.Assert(err, IsNil)
+	c.Assert(wrote, Equals, l)
+	c.Assert(hashOfReader(other), Equals, hash)
+}
+
+func (s *BufferSuite) TestWriteToSmallBuffer(c *C) {
+	l := int64(1)
+	r, hash := createReaderOfSize(l)
+	bb, err := NewBodyBuffer(r)
+	c.Assert(err, IsNil)
+
+	other := &bytes.Buffer{}
+	wrote, err := bb.WriteTo(other)
+	c.Assert(err, IsNil)
+	c.Assert(wrote, Equals, l)
+	c.Assert(hashOfReader(other), Equals, hash)
+}

--- a/proxy.go
+++ b/proxy.go
@@ -92,7 +92,7 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) error {
 		netutils.CopyHeaders(w.Header(), response.Header)
 		w.WriteHeader(response.StatusCode)
 		io.Copy(w, response.Body)
-		defer response.Body.Close()
+		response.Body.Close()
 		return nil
 	} else {
 		return err


### PR DESCRIPTION
Fix connection pooling behavior by reading responses from endpoints sooner.

The faster we read response from endpoint and close the body, the sooner it will be released back to the pool and reused.
In addition to that we improve copying by implementing optimized WriteTo method
