### PR TITLE
Use matching against escaped URLs

### DIFF
--- a/netutils/netutils.go
+++ b/netutils/netutils.go
@@ -20,6 +20,23 @@ func CopyUrl(in *url.URL) *url.URL {
 	return out
 }
 
+// RawPath returns escaped url path section
+func RawPath(in string) (string, error) {
+	u, err := ParseUrl(in)
+	if err != nil {
+		return "", err
+	}
+	vals := strings.SplitN(in, u.Host, 2)
+	if len(vals) != 2 {
+		return "", fmt.Errorf("failed to parse url")
+	}
+	idx := strings.IndexRune(vals[1], '?')
+	if idx == -1 {
+		return vals[1], nil
+	}
+	return vals[1][:idx], nil
+}
+
 // Copies http headers from source to destination
 // does not overide, but adds multiple headers
 func CopyHeaders(dst, src http.Header) {

--- a/netutils/netutils.go
+++ b/netutils/netutils.go
@@ -22,7 +22,7 @@ func CopyUrl(in *url.URL) *url.URL {
 
 // RawPath returns escaped url path section
 func RawPath(in string) (string, error) {
-	u, err := url.Parse(in)
+	u, err := url.ParseRequestURI(in)
 	if err != nil {
 		return "", err
 	}

--- a/netutils/netutils.go
+++ b/netutils/netutils.go
@@ -22,9 +22,16 @@ func CopyUrl(in *url.URL) *url.URL {
 
 // RawPath returns escaped url path section
 func RawPath(in string) (string, error) {
-	u, err := ParseUrl(in)
+	u, err := url.Parse(in)
 	if err != nil {
 		return "", err
+	}
+	if u.Opaque != "" {
+		return u.Opaque, nil
+	}
+	// This is local URL, has no host, return as-is
+	if u.Host == "" {
+		return in, nil
 	}
 	vals := strings.SplitN(in, u.Host, 2)
 	if len(vals) != 2 {

--- a/netutils/netutils_test.go
+++ b/netutils/netutils_test.go
@@ -26,6 +26,23 @@ func (s *NetUtilsSuite) TestParseBadUrl(c *C) {
 	}
 }
 
+// Make sure parseUrl is strict enough not to accept total garbage
+func (s *NetUtilsSuite) TestURLRawPath(c *C) {
+	vals := []struct {
+		URL      string
+		Expected string
+	}{
+		{"http://google.com/", "/"},
+		{"http://google.com/a?q=b", "/a"},
+		{"http://google.com/%2Fvalue/hello", "/%2Fvalue/hello"},
+	}
+	for _, v := range vals {
+		out, err := RawPath(v.URL)
+		c.Assert(err, IsNil)
+		c.Assert(out, Equals, v.Expected)
+	}
+}
+
 //Just to make sure we don't panic, return err and not
 //username and pass and cover the function
 func (s *NetUtilsSuite) TestParseBadHeaders(c *C) {

--- a/netutils/netutils_test.go
+++ b/netutils/netutils_test.go
@@ -35,6 +35,8 @@ func (s *NetUtilsSuite) TestURLRawPath(c *C) {
 		{"http://google.com/", "/"},
 		{"http://google.com/a?q=b", "/a"},
 		{"http://google.com/%2Fvalue/hello", "/%2Fvalue/hello"},
+		{"/home", "/home"},
+		{"/home%2F", "/home%2F"},
 	}
 	for _, v := range vals {
 		out, err := RawPath(v.URL)

--- a/proxy.go
+++ b/proxy.go
@@ -40,6 +40,7 @@ func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// In case if it's redirect error, try the request one more time, but with different URL
 		r.URL = e.URL
 		r.Host = e.URL.Host
+		r.RequestURI = e.URL.String()
 		if err := p.proxyRequest(w, r); err != nil {
 			p.replyError(err, w, r)
 		}

--- a/route/exproute/parse_test.go
+++ b/route/exproute/parse_test.go
@@ -36,6 +36,16 @@ func (s *TrieSuite) TestParseSuccess(c *C) {
 			"GET",
 		},
 		{
+			`TrieRoute("POST", "/helloworld%2F")`,
+			`http://google.com/helloworld%2F`,
+			"POST",
+		},
+		{
+			`TrieRoute("POST", "/helloworld/<name>")`,
+			`http://google.com/helloworld/%2F`,
+			"POST",
+		},
+		{
 			`RegexpRoute("/helloworld")`,
 			`http://google.com/helloworld`,
 			"GET",

--- a/route/exproute/trie.go
+++ b/route/exproute/trie.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/mailgun/vulcan/location"
+	"github.com/mailgun/vulcan/netutils"
 	"github.com/mailgun/vulcan/request"
 )
 
@@ -64,7 +65,10 @@ func (p *trie) match(r request.Request) location.Location {
 		return nil
 	}
 
-	path := r.GetHttpRequest().URL.Path
+	path, err := netutils.RawPath(r.GetHttpRequest().RequestURI)
+	if err != nil {
+		return nil
+	}
 	if len(path) == 0 {
 		path = "/"
 	}

--- a/route/exproute/trie_test.go
+++ b/route/exproute/trie_test.go
@@ -313,7 +313,7 @@ func makeTrie(c *C, path string, location location.Location) (*trie, *constMatch
 func makeReq(url string) request.Request {
 	u := netutils.MustParseUrl(url)
 	return &request.BaseRequest{
-		HttpRequest: &http.Request{URL: u},
+		HttpRequest: &http.Request{URL: u, RequestURI: url},
 	}
 }
 


### PR DESCRIPTION
@r0mant @horkhe Please review this fixes problems with routing of URLs containing escaped slashes and will reduce amount of errors in logs
