### PR TITLE
Make tokenlimiter capable of getting rates from a request header

### DIFF
--- a/limit/tokenbucket/bucket.go
+++ b/limit/tokenbucket/bucket.go
@@ -2,82 +2,124 @@ package tokenbucket
 
 import (
 	"fmt"
-	"github.com/mailgun/timetools"
 	"time"
+
+	"github.com/mailgun/timetools"
 )
 
-type Rate struct {
-	Units  int64
-	Period time.Duration
+const UndefinedDelay = -1
+
+// rate defines token bucket parameters.
+type rate struct {
+	period  time.Duration
+	average int64
+	burst   int64
 }
 
-// Implements token bucket rate limiting algorithm (http://en.wikipedia.org/wiki/Token_bucket)
-// and is used by rate limiters to implement various rate limiting strategies
-type TokenBucket struct {
-	// Maximum amount of tokens available at given time (controls burst rate)
-	maxTokens int64
-	// Specifies the period of the rate
-	refillPeriod time.Duration
-	// Current value of tokens
-	tokens int64
+func (r *rate) String() string {
+	return fmt.Sprintf("rate(%v/%v, burst=%v)", r.average, r.period, r.burst)
+}
+
+// Implements token bucket algorithm (http://en.wikipedia.org/wiki/Token_bucket)
+type tokenBucket struct {
+	// The time period controlled by the bucket in nanoseconds.
+	period time.Duration
+	// The number of nanoseconds that takes to add one more token to the total
+	// number of available tokens. It effectively caches the value that could
+	// have been otherwise deduced from refillRate.
+	timePerToken time.Duration
+	// The maximum number of tokens that can be accumulate in the bucket.
+	burst int64
+	// The number of tokens available for consumption at the moment. It can
+	// nether be larger then capacity.
+	availableTokens int64
 	// Interface that gives current time (so tests can override)
-	timeProvider timetools.TimeProvider
-	lastRefill   time.Time
+	clock timetools.TimeProvider
+	// Tells when tokensAvailable was updated the last time.
+	lastRefresh time.Time
+	// The number of tokens consumed the last time.
+	lastConsumed int64
 }
 
-func NewTokenBucket(rate Rate, maxTokens int64, timeProvider timetools.TimeProvider) (*TokenBucket, error) {
-	if rate.Period == 0 || rate.Units == 0 {
-		return nil, fmt.Errorf("Invalid rate: %v", rate)
+// newTokenBucket crates a `tokenBucket` instance for the specified `Rate`.
+func newTokenBucket(rate *rate, clock timetools.TimeProvider) *tokenBucket {
+	return &tokenBucket{
+		period:          rate.period,
+		timePerToken:    time.Duration(int64(rate.period) / rate.average),
+		burst:           rate.burst,
+		clock:           clock,
+		lastRefresh:     clock.UtcNow(),
+		availableTokens: rate.burst,
 	}
-	if maxTokens <= 0 {
-		return nil, fmt.Errorf("Invalid maxTokens, should be >0: %d", maxTokens)
-	}
-	if timeProvider == nil {
-		return nil, fmt.Errorf("Supply time provider")
-	}
-	return &TokenBucket{
-		refillPeriod: time.Duration(int64(rate.Period) / rate.Units),
-		maxTokens:    maxTokens, // in case of maxBurst is 0, maxTokens available at should be 1
-		timeProvider: timeProvider,
-		lastRefill:   timeProvider.UtcNow(),
-		tokens:       maxTokens,
-	}, nil
 }
 
-// In case if there's enough tokens, consumes tokens and returns 0, nil
-// In case if tokens to consume is larger than max burst returns -1, error
-// In case if there's not enough tokens, returns time to wait till refill
-func (tb *TokenBucket) Consume(tokens int64) (time.Duration, error) {
-	tb.refill()
-	if tokens > tb.maxTokens {
-		return -1, fmt.Errorf("Requested tokens larger than max tokens")
+// consume makes an attempt to consume the specified number of tokens from the
+// bucket. If there are enough tokens available then `0, nil` is returned; if
+// tokens to consume is larger than the burst size, then an error is returned
+// and the delay is not defined; otherwise returned a none zero delay that tells
+// how much time the caller needs to wait until the desired number of tokens
+// will become available for consumption.
+func (tb *tokenBucket) consume(tokens int64) (time.Duration, error) {
+	tb.updateAvailableTokens()
+	tb.lastConsumed = 0
+	if tokens > tb.burst {
+		return UndefinedDelay, fmt.Errorf("Requested tokens larger than max tokens")
 	}
-	if tb.tokens < tokens {
-		return tb.timeToRefill(tokens), nil
+	if tb.availableTokens < tokens {
+		return tb.timeTillAvailable(tokens), nil
 	}
-	tb.tokens -= tokens
+	tb.availableTokens -= tokens
+	tb.lastConsumed = tokens
 	return 0, nil
 }
 
-// Returns the time after the capacity of tokens will reach the
-func (tb *TokenBucket) timeToRefill(tokens int64) time.Duration {
-	missingTokens := tokens - tb.tokens
-	return time.Duration(missingTokens) * tb.refillPeriod
+// rollback reverts effect of the most recent consumption. If the most recent
+// `consume` resulted in an error or a burst overflow, and therefore did not
+// modify the number of available tokens, then `rollback` won't do that either.
+// It is safe to call this method multiple times, for the second and all
+// following calls have no effect.
+func (tb *tokenBucket) rollback() {
+	tb.availableTokens += tb.lastConsumed
+	tb.lastConsumed = 0
 }
 
-func (tb *TokenBucket) refill() {
-	now := tb.timeProvider.UtcNow()
-	timePassed := now.Sub(tb.lastRefill)
+// Update modifies `average` and `burst` fields of the token bucket according
+// to the provided `Rate`
+func (tb *tokenBucket) update(rate *rate) error {
+	if rate.period != tb.period {
+		return fmt.Errorf("Period mismatch: %v != %v", tb.period, rate.period)
+	}
+	tb.timePerToken = time.Duration(int64(tb.period) / rate.average)
+	tb.burst = rate.burst
+	if tb.availableTokens > rate.burst {
+		tb.availableTokens = rate.burst
+	}
+	return nil
+}
 
-	tokens := tb.tokens + int64(timePassed/tb.refillPeriod)
+// timeTillAvailable returns the number of nanoseconds that we need to
+// wait until the specified number of tokens becomes available for consumption.
+func (tb *tokenBucket) timeTillAvailable(tokens int64) time.Duration {
+	missingTokens := tokens - tb.availableTokens
+	return time.Duration(missingTokens) * tb.timePerToken
+}
+
+// updateAvailableTokens updates the number of tokens available for consumption.
+// It is calculated based on the refill rate, the time passed since last refresh,
+// and is limited by the bucket capacity.
+func (tb *tokenBucket) updateAvailableTokens() {
+	now := tb.clock.UtcNow()
+	timePassed := now.Sub(tb.lastRefresh)
+
+	tokens := tb.availableTokens + int64(timePassed/tb.timePerToken)
 	// If we haven't added any tokens that means that not enough time has passed,
 	// in this case do not adjust last refill checkpoint, otherwise it will be
 	// always moving in time in case of frequent requests that exceed the rate
-	if tokens != tb.tokens {
-		tb.lastRefill = now
-		tb.tokens = tokens
+	if tokens != tb.availableTokens {
+		tb.lastRefresh = now
+		tb.availableTokens = tokens
 	}
-	if tb.tokens > tb.maxTokens {
-		tb.tokens = tb.maxTokens
+	if tb.availableTokens > tb.burst {
+		tb.availableTokens = tb.burst
 	}
 }

--- a/limit/tokenbucket/bucket_test.go
+++ b/limit/tokenbucket/bucket_test.go
@@ -1,172 +1,300 @@
 package tokenbucket
 
 import (
-	"github.com/mailgun/timetools"
-	. "gopkg.in/check.v1"
 	"testing"
 	"time"
+
+	"github.com/mailgun/timetools"
+	. "gopkg.in/check.v1"
 )
 
-func TestBucket(t *testing.T) { TestingT(t) }
+func TestTokenBucket(t *testing.T) { TestingT(t) }
 
 type BucketSuite struct {
-	tm *timetools.FreezedTime
+	clock *timetools.FreezedTime
 }
 
 var _ = Suite(&BucketSuite{})
 
 func (s *BucketSuite) SetUpSuite(c *C) {
-	s.tm = &timetools.FreezedTime{
+	s.clock = &timetools.FreezedTime{
 		CurrentTime: time.Date(2012, 3, 4, 5, 6, 7, 0, time.UTC),
 	}
 }
 
 func (s *BucketSuite) TestConsumeSingleToken(c *C) {
-	l, err := NewTokenBucket(Rate{1, time.Second}, 1, s.tm)
-	c.Assert(err, Equals, nil)
+	tb := newTokenBucket(&rate{time.Second, 1, 1}, s.clock)
 
 	// First request passes
-	delay, err := l.Consume(1)
-	c.Assert(err, Equals, nil)
+	delay, err := tb.consume(1)
+	c.Assert(err, IsNil)
 	c.Assert(delay, Equals, time.Duration(0))
 
 	// Next request does not pass the same second
-	delay, err = l.Consume(1)
-	c.Assert(err, Equals, nil)
+	delay, err = tb.consume(1)
+	c.Assert(err, IsNil)
 	c.Assert(delay, Equals, time.Second)
 
 	// Second later, the request passes
-	s.tm.CurrentTime = s.tm.CurrentTime.Add(time.Second)
-	delay, err = l.Consume(1)
-	c.Assert(err, Equals, nil)
+	s.clock.Sleep(time.Second)
+	delay, err = tb.consume(1)
+	c.Assert(err, IsNil)
 	c.Assert(delay, Equals, time.Duration(0))
 
 	// Five seconds later, still only one request is allowed
 	// because maxBurst is 1
-	s.tm.CurrentTime = s.tm.CurrentTime.Add(5 * time.Second)
-	delay, err = l.Consume(1)
-	c.Assert(err, Equals, nil)
+	s.clock.Sleep(5 * time.Second)
+	delay, err = tb.consume(1)
+	c.Assert(err, IsNil)
 	c.Assert(delay, Equals, time.Duration(0))
 
 	// The next one is forbidden
-	delay, err = l.Consume(1)
-	c.Assert(err, Equals, nil)
+	delay, err = tb.consume(1)
+	c.Assert(err, IsNil)
 	c.Assert(delay, Equals, time.Second)
 }
 
 func (s *BucketSuite) TestFastConsumption(c *C) {
-	l, err := NewTokenBucket(Rate{1, time.Second}, 1, s.tm)
-	c.Assert(err, Equals, nil)
+	tb := newTokenBucket(&rate{time.Second, 1, 1}, s.clock)
 
 	// First request passes
-	delay, err := l.Consume(1)
-	c.Assert(err, Equals, nil)
+	delay, err := tb.consume(1)
+	c.Assert(err, IsNil)
 	c.Assert(delay, Equals, time.Duration(0))
 
 	// Try 200 ms later
-	s.tm.CurrentTime = s.tm.CurrentTime.Add(time.Millisecond * 200)
-	delay, err = l.Consume(1)
-	c.Assert(err, Equals, nil)
+	s.clock.Sleep(time.Millisecond * 200)
+	delay, err = tb.consume(1)
+	c.Assert(err, IsNil)
 	c.Assert(delay, Equals, time.Second)
 
 	// Try 700 ms later
-	s.tm.CurrentTime = s.tm.CurrentTime.Add(time.Millisecond * 700)
-	delay, err = l.Consume(1)
-	c.Assert(err, Equals, nil)
+	s.clock.Sleep(time.Millisecond * 700)
+	delay, err = tb.consume(1)
+	c.Assert(err, IsNil)
 	c.Assert(delay, Equals, time.Second)
 
 	// Try 100 ms later, success!
-	s.tm.CurrentTime = s.tm.CurrentTime.Add(time.Millisecond * 100)
-	delay, err = l.Consume(1)
-	c.Assert(err, Equals, nil)
+	s.clock.Sleep(time.Millisecond * 100)
+	delay, err = tb.consume(1)
+	c.Assert(err, IsNil)
 	c.Assert(delay, Equals, time.Duration(0))
 }
 
 func (s *BucketSuite) TestConsumeMultipleTokens(c *C) {
-	l, err := NewTokenBucket(Rate{3, time.Second}, 5, s.tm)
-	c.Assert(err, Equals, nil)
+	tb := newTokenBucket(&rate{time.Second, 3, 5}, s.clock)
 
-	delay, err := l.Consume(3)
-	c.Assert(err, Equals, nil)
+	delay, err := tb.consume(3)
+	c.Assert(err, IsNil)
 	c.Assert(delay, Equals, time.Duration(0))
 
-	delay, err = l.Consume(2)
-	c.Assert(err, Equals, nil)
+	delay, err = tb.consume(2)
+	c.Assert(err, IsNil)
 	c.Assert(delay, Equals, time.Duration(0))
 
-	delay, err = l.Consume(1)
-	c.Assert(err, Equals, nil)
+	delay, err = tb.consume(1)
+	c.Assert(err, IsNil)
 	c.Assert(delay, Not(Equals), time.Duration(0))
 }
 
 func (s *BucketSuite) TestDelayIsCorrect(c *C) {
-	l, err := NewTokenBucket(Rate{3, time.Second}, 5, s.tm)
-	c.Assert(err, Equals, nil)
+	tb := newTokenBucket(&rate{time.Second, 3, 5}, s.clock)
 
 	// Exhaust initial capacity
-	delay, err := l.Consume(5)
-	c.Assert(err, Equals, nil)
+	delay, err := tb.consume(5)
+	c.Assert(err, IsNil)
 	c.Assert(delay, Equals, time.Duration(0))
 
-	delay, err = l.Consume(3)
-	c.Assert(err, Equals, nil)
+	delay, err = tb.consume(3)
+	c.Assert(err, IsNil)
 	c.Assert(delay, Not(Equals), time.Duration(0))
 
 	// Now wait provided delay and make sure we can consume now
-	s.tm.CurrentTime = s.tm.CurrentTime.Add(delay)
-	delay, err = l.Consume(3)
-	c.Assert(err, Equals, nil)
+	s.clock.Sleep(delay)
+	delay, err = tb.consume(3)
+	c.Assert(err, IsNil)
 	c.Assert(delay, Equals, time.Duration(0))
 }
 
 // Make sure requests that exceed burst size are not allowed
 func (s *BucketSuite) TestExceedsBurst(c *C) {
-	l, err := NewTokenBucket(Rate{1, time.Second}, 10, s.tm)
-	c.Assert(err, Equals, nil)
+	tb := newTokenBucket(&rate{time.Second, 1, 10}, s.clock)
 
-	delay, err := l.Consume(11)
-	c.Assert(err, Not(Equals), nil)
-	c.Assert(delay, Equals, time.Duration(-1))
+	_, err := tb.consume(11)
+	c.Assert(err, NotNil)
 }
 
 func (s *BucketSuite) TestConsumeBurst(c *C) {
-	l, err := NewTokenBucket(Rate{2, time.Second}, 5, s.tm)
-	c.Assert(err, Equals, nil)
+	tb := newTokenBucket(&rate{time.Second, 2, 5}, s.clock)
 
 	// In two seconds we would have 5 tokens
-	s.tm.CurrentTime = s.tm.CurrentTime.Add(2 * time.Second)
+	s.clock.Sleep(2 * time.Second)
 
 	// Lets consume 5 at once
-	delay, err := l.Consume(5)
+	delay, err := tb.consume(5)
 	c.Assert(delay, Equals, time.Duration(0))
-	c.Assert(err, Equals, nil)
+	c.Assert(err, IsNil)
 }
 
 func (s *BucketSuite) TestConsumeEstimate(c *C) {
-	l, err := NewTokenBucket(Rate{2, time.Second}, 4, s.tm)
-	c.Assert(err, Equals, nil)
+	tb := newTokenBucket(&rate{time.Second, 2, 4}, s.clock)
 
 	// Consume all burst at once
-	delay, err := l.Consume(4)
-	c.Assert(err, Equals, nil)
+	delay, err := tb.consume(4)
+	c.Assert(err, IsNil)
 	c.Assert(delay, Equals, time.Duration(0))
 
 	// Now try to consume it and face delay
-	delay, err = l.Consume(4)
-	c.Assert(err, Equals, nil)
+	delay, err = tb.consume(4)
+	c.Assert(err, IsNil)
 	c.Assert(delay, Equals, time.Duration(2)*time.Second)
 }
 
-func (s *BucketSuite) TestInvalidParams(c *C) {
-	// Invalid rate
-	_, err := NewTokenBucket(Rate{0, 0}, 1, s.tm)
-	c.Assert(err, Not(Equals), nil)
+// If a rate with different period is passed to the `update` method, then an
+// error is returned but the state of the bucket remains valid and unchanged.
+func (s *BucketSuite) TestUpdateInvalidPeriod(c *C) {
+	// Given
+	tb := newTokenBucket(&rate{time.Second, 10, 20}, s.clock)
+	tb.consume(15) // 5 tokens available
+	// When
+	err := tb.update(&rate{time.Second+1, 30, 40}) // still 5 tokens available
+	// Then
+	c.Assert(err, NotNil)
 
-	// Invalid max tokens
-	_, err = NewTokenBucket(Rate{2, time.Second}, 0, s.tm)
-	c.Assert(err, Not(Equals), nil)
+	// ...check that rate did not change
+	s.clock.Sleep(500 * time.Millisecond)
+	delay, err := tb.consume(11)
+	c.Assert(err, IsNil)
+	c.Assert(delay, Equals, 100*time.Millisecond)
+	delay, err = tb.consume(10)
+	c.Assert(err, IsNil)
+	c.Assert(delay, Equals, time.Duration(0)) // 0 available
 
-	// Invalid time provider
-	_, err = NewTokenBucket(Rate{2, time.Second}, 1, nil)
-	c.Assert(err, Not(Equals), nil)
+	// ...check that burst did not change
+	s.clock.Sleep(40 * time.Second)
+	delay, err = tb.consume(21)
+	c.Assert(err, NotNil)
+	delay, err = tb.consume(20)
+	c.Assert(err, IsNil)
+	c.Assert(delay, Equals, time.Duration(0)) // 0 available
+}
+
+// If the capacity of the bucket is increased by the update then it takes some
+// time to fill the bucket with tokens up to the new capacity.
+func (s *BucketSuite) TestUpdateBurstIncreased(c *C) {
+	// Given
+	tb := newTokenBucket(&rate{time.Second, 10, 20}, s.clock)
+	tb.consume(15) // 5 tokens available
+	// When
+	err := tb.update(&rate{time.Second, 10, 50}) // still 5 tokens available
+	// Then
+	c.Assert(err, IsNil)
+	delay, err := tb.consume(50)
+	c.Assert(err, IsNil)
+	c.Assert(delay, Equals, time.Duration(time.Second/10*45))
+}
+
+// If the capacity of the bucket is increased by the update then it takes some
+// time to fill the bucket with tokens up to the new capacity.
+func (s *BucketSuite) TestUpdateBurstDecreased(c *C) {
+	// Given
+	tb := newTokenBucket(&rate{time.Second, 10, 50}, s.clock)
+	tb.consume(15) // 35 tokens available
+	// When
+	err := tb.update(&rate{time.Second, 10, 20}) // the number of available tokens reduced to 20.
+	// Then
+	c.Assert(err, IsNil)
+	delay, err := tb.consume(21)
+	c.Assert(err, NotNil)
+	c.Assert(delay, Equals, time.Duration(-1))
+}
+
+// If rate is updated then it affects the bucket refill speed.
+func (s *BucketSuite) TestUpdateRateChanged(c *C) {
+	// Given
+	tb := newTokenBucket(&rate{time.Second, 10, 20}, s.clock)
+	tb.consume(15) // 5 tokens available
+	// When
+	err := tb.update(&rate{time.Second, 20, 20}) // still 5 tokens available
+	// Then
+	delay, err := tb.consume(20)
+	c.Assert(err, IsNil)
+	c.Assert(delay, Equals, time.Duration(time.Second/20*15))
+}
+
+// Only the most recent consumption is reverted by `Rollback`.
+func (s *BucketSuite) TestRollback(c *C) {
+	// Given
+	tb := newTokenBucket(&rate{time.Second, 10, 20}, s.clock)
+	tb.consume(8) // 12 tokens available
+	tb.consume(7) // 5 tokens available
+	// When
+	tb.rollback() // 12 tokens available
+	// Then
+	delay, err := tb.consume(12)
+	c.Assert(err, IsNil)
+	c.Assert(delay, Equals, time.Duration(0))
+	delay, err = tb.consume(1)
+	c.Assert(err, IsNil)
+	c.Assert(delay, Equals, 100*time.Millisecond)
+}
+
+// It is safe to call `Rollback` several times. The second and all subsequent
+// calls just do nothing.
+func (s *BucketSuite) TestRollbackSeveralTimes(c *C) {
+	// Given
+	tb := newTokenBucket(&rate{time.Second, 10, 20}, s.clock)
+	tb.consume(8) // 12 tokens available
+	tb.rollback() // 20 tokens available
+	// When
+	tb.rollback() // still 20 tokens available
+	tb.rollback() // still 20 tokens available
+	tb.rollback() // still 20 tokens available
+	// Then: all 20 tokens can be consumed
+	delay, err := tb.consume(20)
+	c.Assert(err, IsNil)
+	c.Assert(delay, Equals, time.Duration(0))
+	delay, err = tb.consume(1)
+	c.Assert(err, IsNil)
+	c.Assert(delay, Equals, 100*time.Millisecond)
+}
+
+// If previous consumption returned a delay due to an attempt to consume more
+// tokens then there are available, then `Rollback` has no effect.
+func (s *BucketSuite) TestRollbackAfterAvailableExceeded(c *C) {
+	// Given
+	tb := newTokenBucket(&rate{time.Second, 10, 20}, s.clock)
+	tb.consume(8)                // 12 tokens available
+	delay, err := tb.consume(15) // still 12 tokens available
+	c.Assert(err, IsNil)
+	c.Assert(delay, Equals, 300*time.Millisecond)
+	// When
+	tb.rollback() // Previous operation consumed 0 tokens, so rollback has no effect.
+	// Then
+	delay, err = tb.consume(12)
+	c.Assert(err, IsNil)
+	c.Assert(delay, Equals, time.Duration(0))
+	delay, err = tb.consume(1)
+	c.Assert(err, IsNil)
+	c.Assert(delay, Equals, 100*time.Millisecond)
+}
+
+// If previous consumption returned a error due to an attempt to consume more
+// tokens then the bucket's burst size, then `Rollback` has no effect.
+func (s *BucketSuite) TestRollbackAfterError(c *C) {
+	// Given
+	tb := newTokenBucket(&rate{time.Second, 10, 20}, s.clock)
+	tb.consume(8)                // 12 tokens available
+	delay, err := tb.consume(21) // still 12 tokens available
+	c.Assert(err, NotNil)
+	c.Assert(delay, Equals, time.Duration(-1))
+	// When
+	tb.rollback() // Previous operation consumed 0 tokens, so rollback has no effect.
+	// Then
+	delay, err = tb.consume(12)
+	c.Assert(err, IsNil)
+	c.Assert(delay, Equals, time.Duration(0))
+	delay, err = tb.consume(1)
+	c.Assert(err, IsNil)
+	c.Assert(delay, Equals, 100*time.Millisecond)
 }

--- a/limit/tokenbucket/bucketset.go
+++ b/limit/tokenbucket/bucketset.go
@@ -1,0 +1,103 @@
+package tokenbucket
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/mailgun/timetools"
+	"sort")
+
+// TokenBucketSet represents a set of TokenBucket covering different time periods.
+type tokenBucketSet struct {
+	buckets   map[time.Duration]*tokenBucket
+	maxPeriod time.Duration
+	clock     timetools.TimeProvider
+}
+
+// newTokenBucketSet creates a `TokenBucketSet` from the specified `rates`.
+func newTokenBucketSet(rates *RateSet, clock timetools.TimeProvider) *tokenBucketSet {
+	tbs := new(tokenBucketSet)
+	tbs.clock = clock
+	// In the majority of cases we will have only one bucket.
+	tbs.buckets = make(map[time.Duration]*tokenBucket, len(rates.m))
+	for _, rate := range rates.m {
+		newBucket := newTokenBucket(rate, clock)
+		tbs.buckets[rate.period] = newBucket
+		tbs.maxPeriod = maxDuration(tbs.maxPeriod, rate.period)
+	}
+	return tbs
+}
+
+// Update brings the buckets in the set in accordance with the provided `rates`.
+func (tbs *tokenBucketSet) update(rates *RateSet) {
+	// Update existing buckets and delete those that have no corresponding spec.
+	for _, bucket := range tbs.buckets {
+		if rate, ok := rates.m[bucket.period]; ok {
+			bucket.update(rate)
+		} else {
+			delete(tbs.buckets, bucket.period)
+		}
+	}
+	// Add missing buckets.
+	for _, rate := range rates.m {
+		if _, ok := tbs.buckets[rate.period]; !ok {
+			newBucket := newTokenBucket(rate, tbs.clock)
+			tbs.buckets[rate.period] = newBucket
+		}
+	}
+	// Identify the maximum period in the set
+	tbs.maxPeriod = 0
+	for _, bucket := range tbs.buckets {
+		tbs.maxPeriod = maxDuration(tbs.maxPeriod, bucket.period)
+	}
+}
+
+func (tbs *tokenBucketSet) consume(tokens int64) (time.Duration, error) {
+	var maxDelay time.Duration = UndefinedDelay
+	var firstErr error = nil
+	for _, tokenBucket := range tbs.buckets {
+		// We keep calling `Consume` even after a error is returned for one of
+		// buckets because that allows us to simplify the rollback procedure,
+		// that is to just call `Rollback` for all buckets.
+		delay, err := tokenBucket.consume(tokens)
+		if firstErr == nil {
+			if err != nil {
+				firstErr = err
+			} else {
+				maxDelay = maxDuration(maxDelay, delay)
+			}
+		}
+	}
+	// If we could not make ALL buckets consume tokens for whatever reason,
+	// then rollback consumption for all of them.
+	if firstErr != nil || maxDelay > 0 {
+		for _, tokenBucket := range tbs.buckets {
+			tokenBucket.rollback()
+		}
+	}
+	return maxDelay, firstErr
+}
+
+// debugState returns string that reflects the current state of all buckets in
+// this set. It is intended to be used for debugging and testing only.
+func (tbs *tokenBucketSet) debugState() string {
+	periods := sort.IntSlice(make([]int, 0, len(tbs.buckets)))
+	for period := range tbs.buckets {
+		periods = append(periods, int(period))
+	}
+	sort.Sort(periods)
+	bucketRepr := make([]string, 0, len(tbs.buckets))
+	for _, period := range periods {
+		bucket := tbs.buckets[time.Duration(period)]
+		bucketRepr = append(bucketRepr, fmt.Sprintf("{%v: %v}", bucket.period, bucket.availableTokens))
+	}
+	return strings.Join(bucketRepr, ", ")
+}
+
+func maxDuration(x time.Duration, y time.Duration) time.Duration {
+	if x > y {
+		return x
+	}
+	return y
+}

--- a/limit/tokenbucket/bucketset_test.go
+++ b/limit/tokenbucket/bucketset_test.go
@@ -1,0 +1,186 @@
+package tokenbucket
+
+import (
+	//	"fmt"
+	"time"
+
+	"github.com/mailgun/timetools"
+	. "gopkg.in/check.v1"
+)
+
+type BucketSetSuite struct {
+	clock *timetools.FreezedTime
+}
+
+var _ = Suite(&BucketSetSuite{})
+
+func (s *BucketSetSuite) SetUpSuite(c *C) {
+	s.clock = &timetools.FreezedTime{
+		CurrentTime: time.Date(2012, 3, 4, 5, 6, 7, 0, time.UTC),
+	}
+}
+
+// A value returned by `MaxPeriod` corresponds to the longest bucket time period.
+func (s *BucketSetSuite) TestLongestPeriod(c *C) {
+	// Given
+	rates := NewRateSet()
+	rates.Add(1*time.Second, 10, 20)
+	rates.Add(7*time.Second, 10, 20)
+	rates.Add(5*time.Second, 11, 21)
+	// When
+	tbs := newTokenBucketSet(rates, s.clock)
+	// Then
+	c.Assert(tbs.maxPeriod, Equals, 7*time.Second)
+}
+
+// Successful token consumption updates state of all buckets in the set.
+func (s *BucketSetSuite) TestConsume(c *C) {
+	// Given
+	rates := NewRateSet()
+	rates.Add(1*time.Second, 10, 20)
+	rates.Add(10*time.Second, 20, 50)
+	tbs := newTokenBucketSet(rates, s.clock)
+	// When
+	delay, err := tbs.consume(15)
+	// Then
+	c.Assert(delay, Equals, time.Duration(0))
+	c.Assert(err, IsNil)
+	c.Assert(tbs.debugState(), Equals, "{1s: 5}, {10s: 35}")
+}
+
+// As time goes by all set buckets are refilled with appropriate rates.
+func (s *BucketSetSuite) TestConsumeRefill(c *C) {
+	// Given
+	rates := NewRateSet()
+	rates.Add(10*time.Second, 10, 20)
+	rates.Add(100*time.Second, 20, 50)
+	tbs := newTokenBucketSet(rates, s.clock)
+	tbs.consume(15)
+	c.Assert(tbs.debugState(), Equals, "{10s: 5}, {1m40s: 35}")
+	// When
+	s.clock.Sleep(10 * time.Second)
+	delay, err := tbs.consume(0) // Consumes nothing but forces an internal state update.
+	// Then
+	c.Assert(delay, Equals, time.Duration(0))
+	c.Assert(err, IsNil)
+	c.Assert(tbs.debugState(), Equals, "{10s: 15}, {1m40s: 37}")
+}
+
+// If the first bucket in the set has no enough tokens to allow desired
+// consumption then an appropriate delay is returned.
+func (s *BucketSetSuite) TestConsumeLimitedBy1st(c *C) {
+	// Given
+	rates := NewRateSet()
+	rates.Add(10*time.Second, 10, 10)
+	rates.Add(100*time.Second, 20, 20)
+	tbs := newTokenBucketSet(rates, s.clock)
+	tbs.consume(5)
+	c.Assert(tbs.debugState(), Equals, "{10s: 5}, {1m40s: 15}")
+	// When
+	delay, err := tbs.consume(10)
+	// Then
+	c.Assert(delay, Equals, 5*time.Second)
+	c.Assert(err, IsNil)
+	c.Assert(tbs.debugState(), Equals, "{10s: 5}, {1m40s: 15}")
+}
+
+// If the second bucket in the set has no enough tokens to allow desired
+// consumption then an appropriate delay is returned.
+func (s *BucketSetSuite) TestConsumeLimitedBy2st(c *C) {
+	// Given
+	rates := NewRateSet()
+	rates.Add(10*time.Second, 10, 10)
+	rates.Add(100*time.Second, 20, 20)
+	tbs := newTokenBucketSet(rates, s.clock)
+	tbs.consume(10)
+	s.clock.Sleep(10 * time.Second)
+	tbs.consume(10)
+	s.clock.Sleep(5 * time.Second)
+	tbs.consume(0)
+	c.Assert(tbs.debugState(), Equals, "{10s: 5}, {1m40s: 3}")
+	// When
+	delay, err := tbs.consume(10)
+	// Then
+	c.Assert(delay, Equals, 7*(5*time.Second))
+	c.Assert(err, IsNil)
+	c.Assert(tbs.debugState(), Equals, "{10s: 5}, {1m40s: 3}")
+}
+
+// An attempt to consume more tokens then the smallest bucket capacity results
+// in error.
+func (s *BucketSetSuite) TestConsumeMoreThenBurst(c *C) {
+	// Given
+	rates := NewRateSet()
+	rates.Add(1*time.Second, 10, 20)
+	rates.Add(10*time.Second, 50, 100)
+	tbs := newTokenBucketSet(rates, s.clock)
+	tbs.consume(5)
+	c.Assert(tbs.debugState(), Equals, "{1s: 15}, {10s: 95}")
+	// When
+	_, err := tbs.consume(21)
+	//Then
+	c.Assert(tbs.debugState(), Equals, "{1s: 15}, {10s: 95}")
+	c.Assert(err, NotNil)
+}
+
+// Update operation can add buckets.
+func (s *BucketSetSuite) TestUpdateMore(c *C) {
+	// Given
+	rates := NewRateSet()
+	rates.Add(1*time.Second, 10, 20)
+	rates.Add(10*time.Second, 20, 50)
+	rates.Add(20*time.Second, 45, 90)
+	tbs := newTokenBucketSet(rates, s.clock)
+	tbs.consume(5)
+	c.Assert(tbs.debugState(), Equals, "{1s: 15}, {10s: 45}, {20s: 85}")
+	rates = NewRateSet()
+	rates.Add(10*time.Second, 30, 40)
+	rates.Add(11*time.Second, 30, 40)
+	rates.Add(12*time.Second, 30, 40)
+	rates.Add(13*time.Second, 30, 40)
+	// When
+	tbs.update(rates)
+	// Then
+	c.Assert(tbs.debugState(), Equals, "{10s: 40}, {11s: 40}, {12s: 40}, {13s: 40}")
+	c.Assert(tbs.maxPeriod, Equals, 13*time.Second)
+}
+
+// Update operation can remove buckets.
+func (s *BucketSetSuite) TestUpdateLess(c *C) {
+	// Given
+	rates := NewRateSet()
+	rates.Add(1*time.Second, 10, 20)
+	rates.Add(10*time.Second, 20, 50)
+	rates.Add(20*time.Second, 45, 90)
+	rates.Add(30*time.Second, 50, 100)
+	tbs := newTokenBucketSet(rates, s.clock)
+	tbs.consume(5)
+	c.Assert(tbs.debugState(), Equals, "{1s: 15}, {10s: 45}, {20s: 85}, {30s: 95}")
+	rates = NewRateSet()
+	rates.Add(10*time.Second, 25, 20)
+	rates.Add(20*time.Second, 30, 21)
+	// When
+	tbs.update(rates)
+	// Then
+	c.Assert(tbs.debugState(), Equals, "{10s: 20}, {20s: 21}")
+	c.Assert(tbs.maxPeriod, Equals, 20*time.Second)
+}
+
+// Update operation can remove buckets.
+func (s *BucketSetSuite) TestUpdateAllDifferent(c *C) {
+	// Given
+	rates := NewRateSet()
+	rates.Add(10*time.Second, 20, 50)
+	rates.Add(30*time.Second, 50, 100)
+	tbs := newTokenBucketSet(rates, s.clock)
+	tbs.consume(5)
+	c.Assert(tbs.debugState(), Equals, "{10s: 45}, {30s: 95}")
+	rates = NewRateSet()
+	rates.Add(1*time.Second, 10, 40)
+	rates.Add(60*time.Second, 100, 150)
+	// When
+	tbs.update(rates)
+	// Then
+	c.Assert(tbs.debugState(), Equals, "{1s: 40}, {1m0s: 150}")
+	c.Assert(tbs.maxPeriod, Equals, 60*time.Second)
+}

--- a/limit/tokenbucket/tokenlimiter.go
+++ b/limit/tokenbucket/tokenlimiter.go
@@ -3,69 +3,96 @@ package tokenbucket
 
 import (
 	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/mailgun/log"
 	"github.com/mailgun/timetools"
 	"github.com/mailgun/ttlmap"
 	"github.com/mailgun/vulcan/errors"
 	"github.com/mailgun/vulcan/limit"
 	"github.com/mailgun/vulcan/netutils"
 	"github.com/mailgun/vulcan/request"
-	"net/http"
-	"sync"
-	"time"
 )
 
+const DefaultCapacity = 65536
+
+// RateSet maintains a set of rates. It can contain only one rate per period at a time.
+type RateSet struct {
+	m map[time.Duration]*rate
+}
+
+// NewRateSet crates an empty `RateSet` instance.
+func NewRateSet() *RateSet {
+	rs := new(RateSet)
+	rs.m = make(map[time.Duration]*rate)
+	return rs
+}
+
+// Add adds a rate to the set. If there is a rate with the same period in the
+// set then the new rate overrides the old one.
+func (rs *RateSet) Add(period time.Duration, average int64, burst int64) error {
+	if period <= 0 {
+		return fmt.Errorf("Invalid period: %v", period)
+	}
+	if average <= 0 {
+		return fmt.Errorf("Invalid average: %v", average)
+	}
+	if burst <= 0 {
+		return fmt.Errorf("Invalid burst: %v", burst)
+	}
+	rs.m[period] = &rate{period, average, burst}
+	return nil
+}
+
+func (rs* RateSet) String() string {
+	return fmt.Sprint(rs.m)
+}
+
+// ConfigMapperFn is a mapper function that is used by the `TokenLimiter`
+// middleware to retrieve `RateSet` from HTTP requests.
+type ConfigMapperFn func(r request.Request) (*RateSet, error)
+
+// TokenLimiter implements rate limiting middleware.
 type TokenLimiter struct {
-	buckets *ttlmap.TtlMap
-	mutex   *sync.Mutex
-	options Options
-	mapper  limit.MapperFn
-	rate    Rate
+	defaultRates *RateSet
+	mapper       limit.MapperFn
+	configMapper ConfigMapperFn
+	clock        timetools.TimeProvider
+	mutex        sync.Mutex
+	bucketSets   *ttlmap.TtlMap
 }
 
-type Options struct {
-	Rate         Rate  // Average allowed rate
-	Burst        int64 // Burst size
-	Capacity     int   // Overall capacity (maximum sumultaneuously active tokens)
-	Mapper       limit.MapperFn
-	TimeProvider timetools.TimeProvider
-}
-
-func NewTokenLimiter(mapper limit.MapperFn, rate Rate) (*TokenLimiter, error) {
-	return NewTokenLimiterWithOptions(mapper, rate, Options{})
-}
-
-func NewTokenLimiterWithOptions(mapper limit.MapperFn, rate Rate, o Options) (*TokenLimiter, error) {
+// NewLimiter constructs a `TokenLimiter` middleware instance.
+func NewLimiter(defaultRates *RateSet, capacity int, mapper limit.MapperFn, configMapper ConfigMapperFn, clock timetools.TimeProvider) (*TokenLimiter, error) {
+	if defaultRates == nil || len(defaultRates.m) == 0 {
+		return nil, fmt.Errorf("Provide default rates")
+	}
 	if mapper == nil {
 		return nil, fmt.Errorf("Provide mapper function")
 	}
-	options, err := parseOptions(o)
-	if err != nil {
-		return nil, err
+
+	// Set default values for optional fields.
+	if capacity <= 0 {
+		capacity = DefaultCapacity
 	}
-	buckets, err := ttlmap.NewMapWithProvider(options.Capacity, options.TimeProvider)
+	if clock == nil {
+		clock = &timetools.RealTime{}
+	}
+
+	bucketSets, err := ttlmap.NewMapWithProvider(DefaultCapacity, clock)
 	if err != nil {
 		return nil, err
 	}
 
 	return &TokenLimiter{
-		rate:    rate,
-		mapper:  mapper,
-		options: options,
-		mutex:   &sync.Mutex{},
-		buckets: buckets,
+		defaultRates: defaultRates,
+		mapper:       mapper,
+		configMapper: configMapper,
+		clock:        clock,
+		bucketSets:   bucketSets,
 	}, nil
-}
-
-func (tl *TokenLimiter) GetRate() Rate {
-	return tl.rate
-}
-
-func (tl *TokenLimiter) GetBurst() int64 {
-	return tl.options.Burst
-}
-
-func (tl *TokenLimiter) GetCapacity() int {
-	return tl.options.Capacity
 }
 
 func (tl *TokenLimiter) ProcessRequest(r request.Request) (*http.Response, error) {
@@ -77,18 +104,21 @@ func (tl *TokenLimiter) ProcessRequest(r request.Request) (*http.Response, error
 		return nil, err
 	}
 
-	bucketI, exists := tl.buckets.Get(token)
-	if !exists {
-		bucketI, err = NewTokenBucket(tl.rate, tl.options.Burst+1, tl.options.TimeProvider)
-		if err != nil {
-			return nil, err
-		}
+	effectiveRates := tl.effectiveRates(r)
+	bucketSetI, exists := tl.bucketSets.Get(token)
+	var bucketSet *tokenBucketSet
+
+	if exists {
+		bucketSet = bucketSetI.(*tokenBucketSet)
+		bucketSet.update(effectiveRates)
+	} else {
+		bucketSet = newTokenBucketSet(effectiveRates, tl.clock)
 		// We set ttl as 10 times rate period. E.g. if rate is 100 requests/second per client ip
 		// the counters for this ip will expire after 10 seconds of inactivity
-		tl.buckets.Set(token, bucketI, int(tl.rate.Period/time.Second)*10+1)
+		tl.bucketSets.Set(token, bucketSet, int(bucketSet.maxPeriod/time.Second)*10+1)
 	}
-	bucket := bucketI.(*TokenBucket)
-	delay, err := bucket.Consume(amount)
+
+	delay, err := bucketSet.consume(amount)
 	if err != nil {
 		return nil, err
 	}
@@ -101,15 +131,24 @@ func (tl *TokenLimiter) ProcessRequest(r request.Request) (*http.Response, error
 func (tl *TokenLimiter) ProcessResponse(r request.Request, a request.Attempt) {
 }
 
-// Check arguments and initialize defaults
-func parseOptions(o Options) (Options, error) {
-	if o.Capacity <= 0 {
-		o.Capacity = DefaultCapacity
+// effectiveRates retrieves rates to be applied to the request.
+func (tl *TokenLimiter) effectiveRates(r request.Request) *RateSet {
+	// If configuration mapper is not specified for this instance, then return
+	// the default bucket specs.
+	if tl.configMapper == nil {
+		return tl.defaultRates
 	}
-	if o.TimeProvider == nil {
-		o.TimeProvider = &timetools.RealTime{}
-	}
-	return o, nil
-}
 
-const DefaultCapacity = 65536
+	rates, err := tl.configMapper(r)
+	if err != nil {
+		log.Errorf("Failed to retrieve rates: %v", err)
+		return tl.defaultRates
+	}
+
+	// If the returned rate set is empty then used the default one.
+	if len(rates.m) == 0 {
+		return tl.defaultRates
+	}
+
+	return rates
+}

--- a/limit/tokenbucket/tokenlimiter_test.go
+++ b/limit/tokenbucket/tokenlimiter_test.go
@@ -1,103 +1,222 @@
 package tokenbucket
 
 import (
-	"github.com/mailgun/timetools"
-	. "github.com/mailgun/vulcan/limit"
-	"github.com/mailgun/vulcan/request"
-	. "gopkg.in/check.v1"
+	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/mailgun/timetools"
+	"github.com/mailgun/vulcan/limit"
+	"github.com/mailgun/vulcan/request"
+	. "gopkg.in/check.v1"
 )
 
 type LimiterSuite struct {
-	tm *timetools.FreezedTime
+	clock *timetools.FreezedTime
 }
 
 var _ = Suite(&LimiterSuite{})
 
 func (s *LimiterSuite) SetUpSuite(c *C) {
-	s.tm = &timetools.FreezedTime{
+	s.clock = &timetools.FreezedTime{
 		CurrentTime: time.Date(2012, 3, 4, 5, 6, 7, 0, time.UTC),
 	}
 }
 
+func (s *LimiterSuite) TestRateSetAdd(c *C) {
+	rs := NewRateSet()
+	
+	// Invalid period
+	err := rs.Add(0, 1, 1)
+	c.Assert(err, NotNil)
+
+	// Invalid Average
+	err = rs.Add(time.Second, 0, 1)
+	c.Assert(err, NotNil)
+
+	// Invalid Burst
+	err = rs.Add(time.Second, 1, 0)
+	c.Assert(err, NotNil)
+
+	err = rs.Add(time.Second, 1, 1)
+	c.Assert(err, IsNil)
+	c.Assert("map[1s:rate(1/1s, burst=1)]", Equals, fmt.Sprint(rs))
+}
+
 // We've hit the limit and were able to proceed on the next time run
 func (s *LimiterSuite) TestHitLimit(c *C) {
-	l, err := NewTokenLimiterWithOptions(
-		MapClientIp, Rate{Units: 1, Period: time.Second}, Options{TimeProvider: s.tm})
-
+	rates := NewRateSet()
+	rates.Add(time.Second, 1, 1)
+	tl, err := NewLimiter(rates, 0, limit.MapClientIp, nil, s.clock)
 	c.Assert(err, IsNil)
-	re, err := l.ProcessRequest(makeRequest("1.2.3.4"))
+
+	re, err := tl.ProcessRequest(makeRequest("1.2.3.4"))
 	c.Assert(re, IsNil)
 	c.Assert(err, IsNil)
 
 	// Next request from the same ip hits rate limit
-	re, err = l.ProcessRequest(makeRequest("1.2.3.4"))
+	re, err = tl.ProcessRequest(makeRequest("1.2.3.4"))
 	c.Assert(re, NotNil)
 	c.Assert(err, IsNil)
 
 	// Second later, the request from this ip will succeed
-	s.tm.CurrentTime = s.tm.CurrentTime.Add(time.Second)
-	re, err = l.ProcessRequest(makeRequest("1.2.3.4"))
+	s.clock.Sleep(time.Second)
+	re, err = tl.ProcessRequest(makeRequest("1.2.3.4"))
 	c.Assert(re, IsNil)
 	c.Assert(err, IsNil)
 }
 
 // We've failed to extract client ip
 func (s *LimiterSuite) TestFailure(c *C) {
-	l, err := NewTokenLimiterWithOptions(
-		MapClientIp, Rate{Units: 1, Period: time.Second}, Options{TimeProvider: s.tm})
+	rates := NewRateSet()
+	rates.Add(time.Second, 1, 1)
+	tl, err := NewLimiter(rates, 0, limit.MapClientIp, nil, s.clock)
 	c.Assert(err, IsNil)
 
-	_, err = l.ProcessRequest(makeRequest(""))
+	_, err = tl.ProcessRequest(makeRequest(""))
 	c.Assert(err, NotNil)
 }
 
-// We've failed to extract client ip
 func (s *LimiterSuite) TestInvalidParams(c *C) {
-	_, err := NewTokenLimiter(nil, Rate{})
+	// Rates are missing
+	_, err := NewLimiter(nil, 0, limit.MapClientIp, nil, s.clock)
 	c.Assert(err, NotNil)
+
+	// Rates are empty
+	_, err = NewLimiter(NewRateSet(), 0, limit.MapClientIp, nil, s.clock)
+	c.Assert(err, NotNil)
+
+	// Mapper is not provided
+	rates := NewRateSet()
+	rates.Add(time.Second, 1, 1)
+	_, err = NewLimiter(rates, 0, nil, nil, s.clock)
+	c.Assert(err, NotNil)
+
+	// Mapper is not provided
+	tl, err := NewLimiter(rates, 0, limit.MapClientIp, nil, s.clock)
+	c.Assert(tl, NotNil)
+	c.Assert(err, IsNil)
 }
 
 // Make sure rates from different ips are controlled separatedly
 func (s *LimiterSuite) TestIsolation(c *C) {
-	l, err := NewTokenLimiterWithOptions(
-		MapClientIp, Rate{Units: 1, Period: time.Second}, Options{TimeProvider: s.tm})
+	rates := NewRateSet()
+	rates.Add(time.Second, 1, 1)
+	tl, err := NewLimiter(rates, 0, limit.MapClientIp, nil, s.clock)
 
-	re, err := l.ProcessRequest(makeRequest("1.2.3.4"))
+	re, err := tl.ProcessRequest(makeRequest("1.2.3.4"))
 	c.Assert(err, IsNil)
 	c.Assert(re, IsNil)
 
 	// Next request from the same ip hits rate limit
-	re, err = l.ProcessRequest(makeRequest("1.2.3.4"))
+	re, err = tl.ProcessRequest(makeRequest("1.2.3.4"))
 	c.Assert(re, NotNil)
 	c.Assert(err, IsNil)
 
 	// The request from other ip can proceed
-	re, err = l.ProcessRequest(makeRequest("1.2.3.5"))
+	re, err = tl.ProcessRequest(makeRequest("1.2.3.5"))
 	c.Assert(err, IsNil)
 	c.Assert(err, IsNil)
 }
 
 // Make sure that expiration works (Expiration is triggered after significant amount of time passes)
 func (s *LimiterSuite) TestExpiration(c *C) {
-	l, err := NewTokenLimiterWithOptions(
-		MapClientIp, Rate{Units: 1, Period: time.Second}, Options{TimeProvider: s.tm})
+	rates := NewRateSet()
+	rates.Add(time.Second, 1, 1)
+	tl, err := NewLimiter(rates, 0, limit.MapClientIp, nil, s.clock)
 
-	re, err := l.ProcessRequest(makeRequest("1.2.3.4"))
+	re, err := tl.ProcessRequest(makeRequest("1.2.3.4"))
 	c.Assert(re, IsNil)
 	c.Assert(err, IsNil)
 
 	// Next request from the same ip hits rate limit
-	re, err = l.ProcessRequest(makeRequest("1.2.3.4"))
+	re, err = tl.ProcessRequest(makeRequest("1.2.3.4"))
 	c.Assert(re, NotNil)
 	c.Assert(err, IsNil)
 
 	// 24 hours later, the request from this ip will succeed
-	s.tm.CurrentTime = s.tm.CurrentTime.Add(24 * time.Hour)
-	re, err = l.ProcessRequest(makeRequest("1.2.3.4"))
+	s.clock.Sleep(24 * time.Hour)
+	re, err = tl.ProcessRequest(makeRequest("1.2.3.4"))
 	c.Assert(err, IsNil)
 	c.Assert(re, IsNil)
+}
+
+// If configMapper returns error, then the default rate is applied.
+func (s *LimiterSuite) TestBadConfigMapper(c *C) {
+	// Given
+	configMapper := func(r request.Request) (*RateSet, error) {
+		return nil, fmt.Errorf("Boom!")
+	}
+	rates := NewRateSet()
+	rates.Add(time.Second, 1, 1)
+	tl, _ := NewLimiter(rates, 0, limit.MapClientIp, configMapper, s.clock)
+	req := makeRequest("1.2.3.4")
+	// When/Then: The default rate is applied, which 1 req/second
+	response, err := tl.ProcessRequest(req) // Processed
+	c.Assert(response, IsNil)
+	c.Assert(err, IsNil)
+	response, err = tl.ProcessRequest(req) // Rejected
+	c.Assert(response, NotNil)
+	c.Assert(err, IsNil)
+
+	s.clock.Sleep(time.Second)
+	response, err = tl.ProcessRequest(req) // Processed
+	c.Assert(response, IsNil)
+	c.Assert(err, IsNil)
+}
+
+// If configMapper returns empty rates, then the default rate is applied.
+func (s *LimiterSuite) TestEmptyConfig(c *C) {
+	// Given
+	configMapper := func(r request.Request) (*RateSet, error) {
+		return NewRateSet(), nil
+	}
+	rates := NewRateSet()
+	rates.Add(time.Second, 1, 1)
+	tl, _ := NewLimiter(rates, 0, limit.MapClientIp, configMapper, s.clock)
+	req := makeRequest("1.2.3.4")
+	// When/Then: The default rate is applied, which 1 req/second
+	response, err := tl.ProcessRequest(req) // Processed
+	c.Assert(response, IsNil)
+	c.Assert(err, IsNil)
+	response, err = tl.ProcessRequest(req) // Rejected
+	c.Assert(response, NotNil)
+	c.Assert(err, IsNil)
+
+	s.clock.Sleep(time.Second)
+	response, err = tl.ProcessRequest(req) // Processed
+	c.Assert(response, IsNil)
+	c.Assert(err, IsNil)
+}
+
+// If rate limiting configuration is valid, then it is applied.
+func (s *LimiterSuite) TestConfigApplied(c *C) {
+	// Given
+	configMapper := func(request.Request) (*RateSet, error) {
+		rates := NewRateSet()
+		rates.Add(time.Second, 2, 2)
+		rates.Add(60*time.Second, 10, 10)
+		return rates, nil
+	}
+	rates := NewRateSet()
+	rates.Add(time.Second, 1, 1)
+	tl, _ := NewLimiter(rates, 0, limit.MapClientIp, configMapper, s.clock)
+	req := makeRequest("1.2.3.4")
+	// When/Then: The configured rate is applied, which 2 req/second
+	response, err := tl.ProcessRequest(req) // Processed
+	c.Assert(response, IsNil)
+	c.Assert(err, IsNil)
+	response, err = tl.ProcessRequest(req) // Processed
+	c.Assert(response, IsNil)
+	c.Assert(err, IsNil)
+	response, err = tl.ProcessRequest(req) // Rejected
+	c.Assert(response, NotNil)
+	c.Assert(err, IsNil)
+
+	s.clock.Sleep(time.Second)
+	response, err = tl.ProcessRequest(req) // Processed
+	c.Assert(response, IsNil)
+	c.Assert(err, IsNil)
 }
 
 func makeRequest(ip string) request.Request {


### PR DESCRIPTION
Ratelimiting middleware can be configured to retrieve Rates to be applied to requests. To do that one needs to pass a **ConfigMapper** function in an **Options** struct to the **NewTokenLimiterFromOptions**. The function should map an http request to a JSON string that configures token buckets for it. There can be configured several token buckets for a request. A request will be allowed by the middleware if all token bucket allow its consumption. The JSON token bucket config should look like this:

``` json
[{"PeriodSec": 1, "Average": 10, "Burst": 20},
 {"PeriodSec": 60, "Average": 100}]
```
